### PR TITLE
WEB-46: Canadian compliance baseline (privacy, terms, CASL, CSP)

### DIFF
--- a/docs/compliance/README.md
+++ b/docs/compliance/README.md
@@ -1,0 +1,24 @@
+# NLG Compliance Artifacts
+
+This folder holds internal compliance documentation for the North
+Lantern Group website. It is **internal working material**, not legal
+advice or certification.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `website-compliance-checklist.md` | The master checklist: Canadian minimum baseline, recommended items, CASL, CAN-SPAM, vendor map, retention, claims register, open questions for counsel, and pre-launch deployment checklist. |
+| `privacy-request-workflow.md` | Operating runbook for privacy@northlanterngroup.com requests: intake, verification, response, escalation, breach handling. |
+
+## How to use this folder
+
+- Update `website-compliance-checklist.md` on every material change to
+  the public site, every new service provider, and every new marketing
+  claim that requires substantiation.
+- Re-review both documents before each production deployment (see the
+  deployment checklist in `website-compliance-checklist.md` §13).
+- Never store personal data here. The privacy request log lives in
+  NLG's internal shared drive, not in the repo.
+- When engaging legal counsel, share `website-compliance-checklist.md`
+  §12 ("Open questions for legal counsel") as the starting agenda.

--- a/docs/compliance/privacy-request-workflow.md
+++ b/docs/compliance/privacy-request-workflow.md
@@ -1,0 +1,147 @@
+# NLG Privacy Request Workflow
+
+**Intake:** privacy@northlanterngroup.com
+**Owner:** North Lantern Group Privacy Office
+**Last reviewed:** April 24, 2026
+
+This is the operating runbook for any request, complaint, or incident
+that arrives at `privacy@northlanterngroup.com`. It is designed to
+support NLG's obligations under PIPEDA. It is not legal advice.
+
+## 1. Inbox setup
+
+- `privacy@northlanterngroup.com` is a Google Workspace group.
+- Monitored by at least **two** trusted internal people (so vacation and
+  illness do not stall the SLA).
+- External posting: **enabled** (anyone must be able to reach us).
+- External conversation viewing: **disabled**.
+- External people joining the group: **disabled**.
+- Inbox retention: inherit default, but do **not** auto-delete on a
+  short rotation — privacy request evidence must be retained.
+
+## 2. Request types we accept
+
+| Type | What it means |
+|------|---------------|
+| Access | "Tell me what personal information you hold about me." |
+| Correction | "Update information you hold that is inaccurate or incomplete." |
+| Deletion | "Delete the personal information you hold about me." |
+| Consent withdrawal | "Stop processing my personal information based on prior consent." |
+| Unsubscribe | "Remove me from commercial electronic messages." Handled within 10 business days per CASL. |
+| Complaint | "I think NLG mishandled my personal information." |
+| Incident / security report | Third-party security researcher or individual reporting a suspected breach, misdirected message, exposed data, or phishing abuse. |
+
+## 3. Service levels
+
+| Stage | Target | Source |
+|-------|--------|--------|
+| Acknowledge receipt | 5 business days | Internal SLA |
+| Substantive response | 30 days from receipt, with a documented extension only where reasonably required under PIPEDA | PIPEDA §8 |
+| Unsubscribe | 10 business days | CASL |
+| Breach notification (if RROSH) | As soon as feasible | PIPEDA §10.1 |
+
+## 4. Step-by-step
+
+### 4.1 Triage (day 0 — day 1)
+
+1. Open the message.
+2. Classify the request type.
+3. Acknowledge receipt with a templated reply that:
+   - Confirms NLG has received the request.
+   - Gives a request ID (see §5).
+   - States the 30-day target (or 10 business days for unsubscribe).
+   - Asks for any information needed to verify identity, but only the
+     minimum needed.
+4. Log the request (see §5).
+
+### 4.2 Verify identity
+
+- For requests involving specific personal information (access,
+  correction, deletion): verify that the requester is the individual
+  the information is about. Acceptable verification varies — for a
+  contact form submitter, matching the email address they submitted is
+  typically enough. If doubt remains, ask for independently
+  verifiable details rather than requesting government ID.
+- For complaints on behalf of another individual, require reasonable
+  authorization.
+
+### 4.3 Investigate
+
+- For **access** requests: enumerate mailboxes, systems, and backups
+  that may hold information about the requester. Export what we find.
+  Redact information about third parties before disclosure.
+- For **correction** requests: make the change, propagate if the record
+  was shared with a service provider, confirm to the requester.
+- For **deletion** requests: confirm whether we have a legal reason to
+  retain (tax, engagement records, CASL suppression list). Delete what
+  is not legally required; explain what we keep and why.
+- For **consent withdrawal**: stop the specific processing the consent
+  covered. Keep the withdrawal evidence itself (to prove we honored it).
+
+### 4.4 Respond
+
+- Reply from `privacy@northlanterngroup.com` (do not reply from a
+  personal mailbox).
+- Explain what we did, what we kept and why, and how to escalate.
+- Close the log entry with the decision and the completion date.
+
+### 4.5 Escalation
+
+- If the request cannot be handled within 30 days: notify the requester
+  **before** the 30-day deadline, give a reason, and commit to a new
+  date.
+- If the request implies a breach: open an incident (see §6).
+- If the requester is unsatisfied: direct them to the Office of the
+  Privacy Commissioner of Canada at priv.gc.ca.
+
+## 5. Log template
+
+Maintain the log inside NLG's internal shared drive, not in this repo
+(the repo is public / semi-public and must not contain personal data).
+
+```
+Request ID:          NLG-PR-YYYY-###
+Received:            2026-MM-DD HH:MM America/Toronto
+Channel:             privacy@northlanterngroup.com
+Requester:           <email> (<company if known>)
+Type:                Access | Correction | Deletion | Withdrawal |
+                     Unsubscribe | Complaint | Incident
+Owner:               <name / role>
+Verification:        Method + date
+Systems searched:    <Google Workspace mailboxes, CRM if any, etc.>
+Decision:            Granted / Partially granted / Denied with reason
+Sent:                2026-MM-DD
+Completed:           2026-MM-DD
+Notes:
+```
+
+## 6. Incident workflow (triggers: suspected breach)
+
+See `website-compliance-checklist.md` §9 for the timeline. Key points:
+
+1. Contain first, investigate second.
+2. Preserve logs.
+3. Apply the RROSH test (Real Risk Of Significant Harm). Factors:
+   sensitivity of data, probability of misuse.
+4. If RROSH is plausible: notify OPC, notify affected individuals.
+5. Record the breach in the breach register for **24 months** minimum,
+   whether or not it required notification (PIPEDA §10.3).
+
+## 7. What we do **not** do
+
+- Share personal information with a third party asking about an
+  individual unless we have clear authorization from that individual.
+- Confirm or deny the existence of a record over email to an
+  unverified requester.
+- Auto-forward `privacy@` to a single person's inbox. Two people
+  minimum, so the SLA survives one person being unavailable.
+- Treat a commercial email unsubscribe the same as a PIPEDA consent
+  withdrawal. They may overlap; they are not identical.
+
+## 8. Changes
+
+Changes to this workflow are logged here.
+
+| Date | Change | Reviewer |
+|------|--------|----------|
+| 2026-04-24 | Initial version | NLG Privacy Office (draft) |

--- a/docs/compliance/website-compliance-checklist.md
+++ b/docs/compliance/website-compliance-checklist.md
@@ -1,0 +1,399 @@
+# North Lantern Group — Website Compliance Checklist
+
+**Scope:** northlanterngroup.com and the Next.js codebase in this repo.
+**Owner:** North Lantern Group Privacy Office — privacy@northlanterngroup.com
+**Last reviewed:** April 24, 2026
+**Status:** Internal working document. Requires legal counsel review before
+launch and on any material change. Not a certification and not legal advice.
+
+This document exists so that a procurement review, a future privacy
+regulator, or a replacement owner can see (1) what we have done, (2) what
+still needs a human decision, and (3) what the operating workflow looks
+like if someone exercises their privacy rights.
+
+The labels below describe what the website is designed to support. They
+do not assert that NLG is "fully compliant," "certified," or "legally
+approved." All of those require human sign-off.
+
+---
+
+## 1. Canadian minimum website compliance baseline
+
+| # | Item | Status | File / Source |
+|---|------|--------|---------------|
+| 1.1 | Privacy Policy published at /privacy with: legal name, Privacy Office contact, last-updated date, data types, purposes, consent, service providers, cross-border, retention, safeguards, rights, complaints, OPC escalation | ✅ Done | `src/app/privacy/page.tsx` |
+| 1.2 | Terms of Use published at /terms covering: informational use, no engagement, no guarantees, IP, prohibited uses, disclaimers, limitation of liability, governing law (Ontario) | ✅ Done | `src/app/terms/page.tsx` |
+| 1.3 | Privacy contact (privacy@northlanterngroup.com) used consistently on Privacy Policy, Terms, Footer, Contact form footer | ✅ Done in code | Privacy, Terms, Footer, Contact |
+| 1.4 | Contact form links to /privacy and /terms before submission | ✅ Done | `Contact.tsx` (checkbox label) |
+| 1.5 | Privacy consent checkbox on contact form — required, unchecked by default | ✅ Done | `Contact.tsx` |
+| 1.6 | Marketing consent — separate, optional, unchecked by default (CASL express-consent capture, not bundled with service consent) | ✅ Done | `Contact.tsx` |
+| 1.7 | reCAPTCHA v3 use disclosed on the form with links to Google privacy and terms | ✅ Done | `Contact.tsx` |
+| 1.8 | ZeroBounce email validation disclosed on the form | ✅ Done | `Contact.tsx` |
+| 1.9 | Honeypot + server-side reCAPTCHA verification + ZeroBounce in the API route | ✅ Done | `src/app/api/contact/route.ts` |
+| 1.10 | No advertising cookies, no analytics trackers, no third-party marketing pixels | ✅ Verified | Repo grep: clean |
+| 1.11 | External links use `rel="noopener noreferrer"` | ✅ Verified | Footer, Contact |
+| 1.12 | Working legal nav in the footer: /privacy, /terms, privacy contact | ✅ Done | `Footer.tsx` |
+| 1.13 | No broken placeholder legal links (`href="#"` etc.) | ✅ Verified | Repo grep: clean |
+| 1.14 | Sitemap includes /privacy and /terms | ✅ Done | `src/app/sitemap.ts` |
+| 1.15 | Privacy contact inbox is monitored by at least two trusted internal people, external posting enabled, external conversation viewing disabled, external joining disabled | ⚠️ **TODO — company confirmation** | Google Workspace group setting |
+| 1.16 | "We do not sell personal information" statement on Privacy Policy | ✅ Done | Privacy §4 |
+| 1.17 | Consent withdrawal mechanism documented on Privacy Policy | ✅ Done | Privacy §5 |
+| 1.18 | Cross-border processing disclosure on Privacy Policy | ✅ Done | Privacy §7 |
+| 1.19 | Retention framework disclosed on Privacy Policy | ✅ Done | Privacy §8 |
+| 1.20 | Complaint escalation to OPC disclosed on Privacy Policy | ✅ Done | Privacy §11 |
+
+---
+
+## 2. Recommended compliance items
+
+| # | Item | Status | Notes |
+|---|------|--------|-------|
+| 2.1 | Security headers: HSTS, X-Content-Type-Options, Referrer-Policy, Permissions-Policy, X-Frame-Options, Cross-Origin-Opener-Policy | ✅ Done | `next.config.ts` |
+| 2.2 | Content-Security-Policy in report-only mode | ✅ Done | `next.config.ts` |
+| 2.3 | Content-Security-Policy switched from report-only to enforcing after observation window | ⚠️ Follow-up | After 30+ days observation in production with no genuine violations |
+| 2.4 | Canonical URL metadata on all public pages | ✅ Done | Home, Privacy, Terms |
+| 2.5 | Sitemap and robots.txt live | ✅ Done | `src/app/sitemap.ts`, `src/app/robots.ts` |
+| 2.6 | No indexing of preview deployments | ✅ Done | `X-Robots-Tag: noindex, nofollow` on non-production |
+| 2.7 | JSON-LD (Organization / ProfessionalService) with consistent NAP data | ✅ Done | `src/app/layout.tsx` |
+| 2.8 | `prefers-reduced-motion` respected globally | ✅ Done | `globals.css` global guard + component-local handling |
+| 2.9 | Focus-visible styles on all interactive controls | ✅ Done | `globals.css` |
+| 2.10 | Form labels, error messages, aria-describedby wired up | ✅ Done | `Contact.tsx` |
+| 2.11 | Phone number input keeps phone optional | ✅ Kept | `Contact.tsx` |
+| 2.12 | WCAG 2.2 AA audit using an automated tool (axe, Lighthouse a11y) | ⚠️ **TODO** | Run `npx @axe-core/cli` or Lighthouse against /, /privacy, /terms |
+| 2.13 | Manual keyboard-only walkthrough (tab order, focus traps, skip links) | ⚠️ **TODO** | Before launch |
+| 2.14 | OG preview image is accessible and represents current brand (not a stale v1 logo) | ✅ Done | `src/app/opengraph-image.tsx` |
+| 2.15 | `npm audit` reviewed; high/critical vulnerabilities addressed | ⚠️ **Tracked** | As of 2026-04-24: three moderate advisories in the transitive chain `resend → svix → uuid < 14.0.0` (GHSA-w5hq-g745-h8pq: missing buffer bounds check in uuid v3/v5/v6 when `buf` is provided). NLG code path uses `resend.emails.send()` only, which does not exercise the vulnerable code path, so runtime exposure is low. Remediation path: wait for svix to upgrade its uuid dep, or downgrade to `resend@6.1.3`. Re-run `npm audit` quarterly. |
+| 2.16 | Third-party dependency minimization | ✅ Ongoing | Only Resend, ZeroBounce, Google reCAPTCHA as runtime dependencies |
+
+---
+
+## 3. CASL checklist — for any future commercial electronic message (CEM)
+
+Canada's Anti-Spam Legislation applies to any commercial electronic
+message sent to an electronic address in Canada. NLG does not currently
+send marketing email from this website. When we begin, every CEM must
+meet **every** item below.
+
+### 3.1 Consent
+
+- [ ] Express consent obtained and logged, with date, method, and the
+      exact wording the recipient agreed to. Pre-checked boxes are not
+      acceptable.
+- [ ] Implied consent only used where legally available (existing
+      business relationship within 2 years of a purchase, within 6 months
+      of an inquiry, conspicuous publication of a business address that
+      is relevant to the recipient's role, etc.). Each implied-consent
+      basis documented per recipient.
+- [ ] B2B-to-B2B exemption relied on **only** where both organizations
+      have an established relationship and the message concerns the
+      recipient organization's activities. Documented per list.
+
+### 3.2 Identification (every message must include)
+
+- [ ] Sender legal name: **North Lantern Group Inc.**
+- [ ] NLG mailing address: **400 Slater St., Ottawa, ON K1R 7S7, Canada**
+- [ ] A contact method (email, phone, or web form) valid for at least 60 days
+- [ ] If sent on behalf of another organization, identify that
+      organization too
+
+### 3.3 Unsubscribe
+
+- [ ] Functioning unsubscribe mechanism in every message
+- [ ] Mechanism must be simple, no-cost, and at least as easy as
+      subscribing
+- [ ] Valid for at least 60 days after the message was sent
+- [ ] Unsubscribe requests processed within 10 business days
+- [ ] Suppression list maintained centrally — no marketing email sent to
+      any address on the list
+
+### 3.4 Records
+
+- [ ] Evidence of consent retained for 3+ years (Canadian regulator
+      guidance; extend per retention schedule)
+- [ ] Unsubscribe timestamps logged
+
+---
+
+## 4. CAN-SPAM readiness — for any future US-facing commercial email
+
+| Item | Requirement |
+|------|-------------|
+| Accurate header information | "From," "To," "Reply-To," and routing must identify the sender |
+| Honest subject lines | No deceptive subject lines |
+| Identify message as an ad | If promotional, must be clearly identifiable (context or disclosure) |
+| Physical postal address | Include a valid physical address in every message |
+| Opt-out mechanism | Functioning opt-out; honor within 10 business days; no payment to unsubscribe |
+| Monitor what others do on our behalf | NLG remains responsible if a third party sends on our behalf |
+
+Ensure every future US-facing CEM satisfies both CASL (stricter) and
+CAN-SPAM. CASL satisfaction typically satisfies CAN-SPAM.
+
+---
+
+## 5. Vendor / data map
+
+Names confirmed from this repository and from published public policy.
+Locations are provider-stated jurisdictions and may change; verify before
+relying on them for a procurement response.
+
+| Provider | Function | Personal data categories | Location (provider-stated) | Contract basis |
+|----------|----------|--------------------------|----------------------------|----------------|
+| Vercel Inc. | Hosting, edge network, build, logs | Request metadata, IP, user agent | Global (primary US) | Vercel DPA (TODO: confirm acceptance) |
+| Resend | Transactional email delivery (contact form) | Submitter name, email, phone (if provided), company, message body | US | Resend DPA (TODO: confirm acceptance) |
+| ZeroBounce | Email address validation | Submitter email address only | US | ZeroBounce DPA (TODO: confirm acceptance) |
+| Google reCAPTCHA v3 | Bot-score risk signal | IP, browser signals, request context | Global (Google infrastructure) | Google Terms & Privacy |
+| Google Workspace | Corporate email (receives submissions, privacy requests) | Full submission contents | Global (Google infrastructure) | Google Workspace MSA + DPA |
+
+**TODOs:**
+- [ ] Confirm executed DPA (data processing agreement) is on file for Vercel, Resend, ZeroBounce.
+- [ ] Confirm Google Workspace data protection terms are accepted.
+- [ ] When adding any new provider, update this table and the Privacy Policy §6.
+
+---
+
+## 6. Personal information inventory
+
+What personal information the website actually handles.
+
+| Data element | Collected from | Collected via | Purpose | Lawful basis | Retention |
+|--------------|----------------|---------------|---------|--------------|-----------|
+| First / last name | Visitor | Contact form | Respond, route | Consent (form submission) | 24 months if no engagement; then delete/anonymize |
+| Company, company size | Visitor | Contact form | Qualify, route | Consent | 24 months if no engagement |
+| Work email | Visitor | Contact form | Respond | Consent | 24 months if no engagement |
+| Phone (optional) | Visitor | Contact form | Respond | Consent | 24 months if no engagement |
+| Area of interest, message body | Visitor | Contact form | Respond, route | Consent | 24 months if no engagement |
+| Marketing consent flag | Visitor | Contact form | CASL proof of consent if we later begin sending CEMs | Consent | As long as consent remains valid (plus 3 years for evidentiary retention once withdrawn) |
+| IP address, user agent, request metadata | Visitor | Automatic (server logs) | Security, abuse prevention | Legitimate operational interest | Rolling 30–90 days depending on provider |
+| reCAPTCHA signals | Visitor | Automatic (Google SDK) | Spam prevention | Legitimate operational interest | Retained by Google per their policy |
+
+**TODO — confirm:** inbox retention policies in Google Workspace (how
+long the received submission email actually lives in `leads@` and
+`privacy@` before it is archived, exported to a CRM, or deleted).
+
+---
+
+## 7. Retention schedule
+
+| Record type | Retention | Trigger for deletion / review |
+|-------------|-----------|-------------------------------|
+| Contact form email, no engagement | 24 months | Age out + quarterly inbox review |
+| Contact form email, became engagement | Per engagement agreement + CRA records retention (6 years for tax-relevant business records) | End of retention window |
+| Marketing consent record | Until consent is withdrawn + 3 years | Evidence of compliance with CASL |
+| Suppression / unsubscribe list | Indefinitely | Required to honor opt-outs |
+| Privacy request log | 3 years | Year + 1 review |
+| Server access logs | Provider default (Vercel) | Provider policy |
+| reCAPTCHA logs | Provider default (Google) | Provider policy |
+
+**TODO — company decision:** confirm whether NLG wants a shorter contact-
+form retention (e.g., 12 months) for privacy-forward posture, or the 24
+months currently documented in the Privacy Policy.
+
+---
+
+## 8. Privacy request workflow
+
+### Intake channel
+`privacy@northlanterngroup.com` — monitored by the NLG Privacy Office.
+At least two trusted internal people must have access to this inbox.
+
+### Request types accepted
+- Access ("what do you hold about me")
+- Correction
+- Deletion
+- Consent withdrawal
+- Unsubscribe (also processed from any CEM footer once CEMs exist)
+- Complaint about our handling of personal information
+- Security / privacy incident report
+
+### Service levels
+| Stage | Target |
+|-------|--------|
+| Acknowledge receipt | Within 5 business days |
+| Substantive response | Within 30 days of receipt, unless more time is reasonably required under PIPEDA. If extension is needed, notify the requester with the reason and the expected date. |
+| Unsubscribe | Within 10 business days (CASL) |
+
+### Log fields (maintain for every request)
+| Field | Example |
+|-------|---------|
+| Request ID | NLG-PR-2026-001 |
+| Received date | 2026-04-24 |
+| Requester identifier | email, name |
+| Request type | Access |
+| Assigned owner | Privacy Office lead |
+| Verification step completed? | Y/N |
+| Decision | Granted / partially granted / denied with reason |
+| Completion date | 2026-05-18 |
+| Notes | |
+
+### Escalation
+- Internal: Founder / executive lead if response period must be extended
+  or if the request indicates a possible breach.
+- External: Office of the Privacy Commissioner of Canada (priv.gc.ca) if
+  the requester is not satisfied with our response.
+
+---
+
+## 9. Breach / incident workflow
+
+PIPEDA requires organizations to (a) report breaches of security
+safeguards involving real risk of significant harm (RROSH) to the OPC
+as soon as feasible, (b) notify affected individuals, and (c) keep a
+record of every breach for 24 months.
+
+### First hour
+1. Contain the incident (rotate keys, revoke access, take affected
+   systems offline if needed).
+2. Open an incident ticket and assign an incident commander.
+3. Preserve logs.
+
+### First 24 hours
+4. Identify the data elements, number of individuals, and likelihood of
+   misuse.
+5. Assess whether a "real risk of significant harm" test is met.
+6. Draft preliminary communication to affected individuals.
+
+### Within days
+7. If RROSH: file OPC breach report, notify affected individuals,
+   notify other relevant regulators.
+8. Post-incident review: root cause, corrective actions, update this
+   playbook.
+
+### Always
+- Maintain a breach register for 24 months (even for breaches not
+  requiring notification).
+
+**TODO — company confirmation:** assign an incident commander (role, not
+a person, to avoid single-point dependency). Confirm the out-of-hours
+contact path.
+
+---
+
+## 10. Marketing claim substantiation register
+
+The public website is currently free of numeric/statistical claims. The
+only recurring marketing claims to track are operational commitments:
+
+| Claim | Where it appears | Substantiation category | Substantiation status |
+|-------|------------------|-------------------------|-----------------------|
+| "Senior operators, no pass-downs" | Hero, TrustStrip, footer tag | Operating commitment | Substantiated by engagement model (same team scoping, building, handing back). Add a brief in the compliance folder if asked. |
+| "Same team from first call to handover" | Hero sub, TrustStrip, footer tag | Operating commitment | Substantiated by engagement model |
+| "Work that sticks after handover" | TrustStrip | Operating commitment | Substantiated by handover runbook + review cadence in HowWeWork |
+| "We reply within one business day" | Contact form status / privacy page | Operating commitment | Substantiated by inbox SLA — **TODO — formalize SLA internally** |
+| Three practices and the capabilities listed under each | Practices section | Descriptive | Substantiated by current engagement experience. No numbers claimed. |
+| Writing section "Coming 2026" essays | Writing section | Forward-looking | Clearly labelled as upcoming; no claim made about volume or frequency. |
+
+### Rule for future content
+Before adding any of the following to the public site, file a
+substantiation note in this register:
+- Percentages, counts, multipliers ("x faster," "2x fewer incidents")
+- Superlatives ("leading," "best," "fastest")
+- Client names, testimonials, case studies, logos
+- Guarantees of a specific outcome, timeline, or dollar value
+- Security or privacy certifications (SOC 2, ISO 27001, Cyber Essentials,
+  etc.) — must be current and auditor-issued
+- Any use of the word "guaranteed," "certified," or "proven" in a
+  marketing context
+
+If a claim cannot be substantiated from NLG-controlled evidence, don't
+publish it. Competition Bureau Canada enforces false-or-misleading
+representations under the Competition Act.
+
+---
+
+## 11. Accessibility
+
+Target: WCAG 2.2 AA as a recommended professional baseline. AODA
+(Accessibility for Ontarians with Disabilities Act) may impose formal
+obligations depending on NLG's size and status — confirm with counsel
+and, if applicable, file the required accessibility compliance report.
+
+| Item | Status |
+|------|--------|
+| Keyboard navigation works across all interactive controls | ✅ Spot-checked; full manual audit **TODO before launch** |
+| Focus-visible styling | ✅ globals.css |
+| Form labels, required marking, error messaging | ✅ Contact form |
+| Colour contrast against NLG dark surfaces | ⚠️ **TODO** — automated contrast audit with axe / Lighthouse |
+| `prefers-reduced-motion` support | ✅ Global guard + component-local |
+| Screen reader names on icon-only buttons (menu, LinkedIn) | ✅ aria-label present |
+| Skip-to-content link | ⚠️ **TODO — add** if manual audit surfaces keyboard traps |
+| Automated a11y audit | ⚠️ **TODO** — run axe / Lighthouse, capture results in this folder |
+
+---
+
+## 12. Open questions for legal counsel
+
+These are the items we do **not** want to assume on our own:
+
+1. Confirm whether the JSON-LD address (400 Slater St., Ottawa, ON K1R
+   7S7) is the appropriate address to publish on privacy / terms / CASL
+   footer, or whether a different registered-office or mailing address
+   should be used.
+2. Confirm "Ontario, Canada" is the correct governing law for the
+   website terms. If NLG is incorporated federally, confirm whether a
+   broader "Canada" choice-of-law is preferable or whether Ontario
+   specifically is acceptable.
+3. Confirm the limitation-of-liability cap structure in §8 of /terms
+   (CAD $100 or amount paid) is acceptable and does not conflict with
+   Ontario Consumer Protection Act principles for any B2C adjacent
+   traffic.
+4. Confirm that NLG does not currently, and does not plan to, monitor
+   or target individuals in the EU/UK to the extent that GDPR / UK GDPR
+   apply. If targeting changes (marketing campaigns, EU office, EU
+   clients with data subjects), revise this baseline upward (lawful
+   basis, data subject rights, DPA, possible DPO).
+5. Confirm the 24-month retention for non-converting inquiries is
+   acceptable, or adjust.
+6. Confirm whether a separate "candidate / careers" data flow should be
+   anticipated (the site does not currently have a careers page).
+7. Confirm whether any current or planned sub-processor (Vercel, Resend,
+   ZeroBounce, Google) has executed the standard contractual safeguards
+   expected by Canadian privacy regulators for cross-border processing.
+8. Confirm whether AODA website compliance reporting applies to NLG
+   based on employee count and organizational status, and, if so, when
+   the next filing is due.
+9. Confirm whether a statement about automated decision-making is
+   required (Law 25 §12.1 for Quebec residents). The form is
+   human-reviewed; reCAPTCHA produces a risk score but does not
+   auto-reject users.
+10. Before launching any future commercial electronic message program,
+    run the CASL checklist (§3) past counsel.
+
+---
+
+## 13. Deployment checklist (pre-go-live)
+
+Run through this list before flipping the site to production, and every
+time material content changes.
+
+- [ ] `npm ci`
+- [ ] `npm run lint` passes
+- [ ] `npm run build` passes
+- [ ] Manual QA: submit the contact form from a real email, confirm
+      delivery to `leads@`, confirm Privacy Policy + Terms links open,
+      confirm marketing-consent checkbox renders and is unchecked by
+      default
+- [ ] Confirm `privacy@northlanterngroup.com` is a live inbox monitored
+      by at least two people
+- [ ] Confirm Privacy Policy "Last updated" date reflects today
+- [ ] Confirm Terms "Last updated" date reflects today
+- [ ] Confirm OG preview (LinkedIn Post Inspector, Facebook Sharing
+      Debugger, Slack unfurl) shows the current dark v2 image
+- [ ] Response headers on production include HSTS, X-Content-Type-
+      Options, Referrer-Policy, Permissions-Policy, X-Frame-Options,
+      CSP-Report-Only
+- [ ] robots.txt not blocking production, preview deployments are
+      `noindex, nofollow`
+- [ ] `npm audit --omit=dev` reviewed; no unaddressed high / critical
+- [ ] Compliance checklist (this document) re-signed by a human owner
+
+---
+
+## Reference
+
+- Office of the Privacy Commissioner of Canada — https://www.priv.gc.ca
+- PIPEDA fair information principles — https://www.priv.gc.ca/en/privacy-topics/privacy-laws-in-canada/the-personal-information-protection-and-electronic-documents-act-pipeda/pipeda_brief/
+- CRTC CASL landing page — https://crtc.gc.ca/eng/internet/anti.htm
+- CASL FAQ — https://crtc.gc.ca/eng/com500/faq500.htm
+- Quebec CAI (Commission d'accès à l'information) — https://www.cai.gouv.qc.ca
+- Competition Bureau Canada — https://competition-bureau.canada.ca
+- WCAG 2.2 — https://www.w3.org/TR/WCAG22/

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,34 @@
 import type { NextConfig } from "next";
 
+// Report-only CSP. It does not block anything; it only reports violations
+// to the browser console and (if configured) a report endpoint. Once the
+// policy has been observed in production for a reasonable period without
+// breakage, switch `Content-Security-Policy-Report-Only` to
+// `Content-Security-Policy` to enforce it.
+//
+// Third-party origins accounted for:
+//   - Google reCAPTCHA v3 script (https://www.google.com/recaptcha/...,
+//     https://www.gstatic.com/recaptcha/...)
+//   - Google Fonts are NOT used at runtime (next/font self-hosts them)
+//
+// `'unsafe-inline'` on script-src is currently required by Next.js runtime
+// chunks and the JSON-LD <script type="application/ld+json"> in the root
+// layout. Migrating to strict-dynamic with nonces is a follow-up.
+const contentSecurityPolicyReportOnly = [
+  "default-src 'self'",
+  "base-uri 'self'",
+  "frame-ancestors 'self'",
+  "form-action 'self'",
+  "img-src 'self' data: blob:",
+  "font-src 'self' data:",
+  "style-src 'self' 'unsafe-inline'",
+  "script-src 'self' 'unsafe-inline' https://www.google.com/recaptcha/ https://www.gstatic.com/recaptcha/",
+  "frame-src https://www.google.com/recaptcha/",
+  "connect-src 'self' https://www.google.com/recaptcha/",
+  "object-src 'none'",
+  "upgrade-insecure-requests",
+].join("; ");
+
 const nextConfig: NextConfig = {
   async headers() {
     const isProduction = process.env.VERCEL_ENV === "production";
@@ -18,7 +47,19 @@ const nextConfig: NextConfig = {
       },
       {
         key: "Permissions-Policy",
-        value: "camera=(), microphone=(), geolocation=()",
+        value: "camera=(), microphone=(), geolocation=(), interest-cohort=()",
+      },
+      {
+        key: "X-Frame-Options",
+        value: "SAMEORIGIN",
+      },
+      {
+        key: "Cross-Origin-Opener-Policy",
+        value: "same-origin",
+      },
+      {
+        key: "Content-Security-Policy-Report-Only",
+        value: contentSecurityPolicyReportOnly,
       },
       ...(isProduction
         ? []

--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -161,9 +161,10 @@ export async function POST(request: Request) {
       message: string;
       captchaToken: string;
       website?: string;
+      marketingConsent?: boolean;
     }
 
-    const { firstName, lastName, company, companySize, email, phone, service, message, captchaToken, website: honeypot }: ContactFormData = await request.json();
+    const { firstName, lastName, company, companySize, email, phone, service, message, captchaToken, website: honeypot, marketingConsent }: ContactFormData = await request.json();
 
     // Validate required fields
     if (!company || !email || !service || !message || message.trim().length < 30) {
@@ -215,6 +216,8 @@ export async function POST(request: Request) {
     const safePhone = phone ? escapeHtml(phone) : '';
     const safeServiceDisplay = escapeHtml(serviceDisplay);
     const safeMessage = escapeHtml(message || 'No message provided');
+    const marketingConsentLabel = marketingConsent ? 'Yes (marketing updates opt-in)' : 'No';
+    const safeMarketingConsent = escapeHtml(marketingConsentLabel);
 
     const emailContent = `
 New Contact Form Submission
@@ -225,6 +228,7 @@ Company Size: ${companySize || 'Not provided'}
 Email: ${email}
 Phone: ${phone || 'Not provided'}
 Area of Interest: ${serviceDisplay}
+Marketing consent: ${marketingConsentLabel}
 Message: ${message || 'No message provided'}
     `.trim();
 
@@ -272,6 +276,10 @@ Message: ${message || 'No message provided'}
       <div class="field">
         <p class="label">Area of Interest:</p>
         <p class="value">${safeServiceDisplay}</p>
+      </div>
+      <div class="field">
+        <p class="label">Marketing consent:</p>
+        <p class="value">${safeMarketingConsent}</p>
       </div>
       <div class="field">
         <p class="label">Message:</p>

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -3,23 +3,23 @@ import Link from "next/link";
 
 export const metadata: Metadata = {
   title: "Privacy Policy | North Lantern Group",
-  description: "Privacy policy for North Lantern Group Inc. website inquiries and contact form submissions.",
+  description:
+    "How North Lantern Group Inc. handles personal information submitted through its website. Our privacy practices, your rights, and how to contact the NLG Privacy Office.",
   alternates: {
     canonical: "https://www.northlanterngroup.com/privacy",
   },
 };
 
-const serviceProviders = [
-  "Resend for email delivery",
-  "ZeroBounce for email validation",
-  "Google reCAPTCHA v3 for spam protection",
-];
+const LAST_UPDATED = "April 24, 2026";
 
 export default function PrivacyPage() {
   return (
     <main className="min-h-screen bg-neutral-950 text-white">
       <section className="mx-auto max-w-3xl px-6 py-16 md:py-24">
-        <Link href="/" className="text-sm font-medium text-cyan-400 hover:text-cyan-300">
+        <Link
+          href="/"
+          className="text-sm font-medium text-cyan-400 hover:text-cyan-300"
+        >
           Back to North Lantern Group
         </Link>
 
@@ -28,82 +28,384 @@ export default function PrivacyPage() {
             Privacy Policy
           </p>
           <h1 className="mt-4 text-3xl md:text-5xl font-semibold tracking-tight">
-            How we handle website inquiries.
+            How we handle personal information.
           </h1>
+          <p className="mt-6 text-sm text-neutral-500">
+            Last updated: {LAST_UPDATED}
+          </p>
           <p className="mt-6 text-neutral-400 leading-relaxed">
-            This policy covers personal information submitted through the North Lantern Group website contact form.
-            We collect what we need to respond, qualify the request, and route the work into the right engagement lane.
+            This policy explains how North Lantern Group Inc. (&quot;NLG,&quot;
+            &quot;we,&quot; &quot;us&quot;) handles personal information
+            collected through northlanterngroup.com. It is designed to support
+            our obligations under Canada&apos;s{" "}
+            <em>
+              Personal Information Protection and Electronic Documents Act
+            </em>{" "}
+            (PIPEDA) and related provincial privacy laws. It is not legal
+            advice.
           </p>
         </div>
 
         <div className="mt-10 space-y-10 text-neutral-300">
           <section>
-            <h2 className="text-xl font-semibold text-white">Organization responsible for the data</h2>
+            <h2 className="text-xl font-semibold text-white">
+              1. Who is responsible for your information
+            </h2>
+            <p className="mt-4 leading-relaxed">
+              North Lantern Group Inc. is the organization responsible for
+              personal information collected through this website. Our Privacy
+              Office is accountable for compliance with this policy and for
+              responding to privacy questions, requests, and complaints.
+            </p>
             <address className="mt-4 not-italic leading-relaxed text-neutral-300">
-              North Lantern Group Inc.<br />
-              400 Slater St.<br />
-              Ottawa, ON K1R 7S7<br />
+              North Lantern Group Privacy Office
+              <br />
+              North Lantern Group Inc.
+              <br />
+              400 Slater St.
+              <br />
+              Ottawa, ON K1R 7S7
+              <br />
               Canada
+              <br />
+              Email:{" "}
+              <a
+                href="mailto:privacy@northlanterngroup.com"
+                className="text-cyan-400 hover:text-cyan-300"
+              >
+                privacy@northlanterngroup.com
+              </a>
             </address>
           </section>
 
           <section>
-            <h2 className="text-xl font-semibold text-white">What we collect</h2>
+            <h2 className="text-xl font-semibold text-white">
+              2. Scope of this policy
+            </h2>
             <p className="mt-4 leading-relaxed">
-              When you submit the contact form, we collect the information you provide: name, company, company size,
-              email address, phone number if provided, area of interest, and message content. We also process technical
-              signals needed to protect the form from spam.
+              This policy applies to personal information we collect through
+              northlanterngroup.com, including the contact form, and through
+              email correspondence initiated from the website. It does not
+              cover information collected under a signed client engagement
+              agreement, which is governed by that agreement and any
+              supporting data processing terms.
             </p>
           </section>
 
           <section>
-            <h2 className="text-xl font-semibold text-white">Why we collect it</h2>
+            <h2 className="text-xl font-semibold text-white">
+              3. What personal information we collect
+            </h2>
             <p className="mt-4 leading-relaxed">
-              We use your submission to respond to the inquiry, understand the fit, and route the request into one of
-              three lanes: Atlassian Systems, BI and Operational Reporting, or Automation and Integration.
+              We collect only what is needed to respond to inquiries, qualify
+              the request, and route it to the right engagement lane.
+            </p>
+            <p className="mt-4 leading-relaxed font-medium text-white">
+              Information you provide to us:
+            </p>
+            <ul className="mt-2 list-disc space-y-2 pl-5">
+              <li>
+                Name (first, last), company, company size, work email, and
+                phone number (optional)
+              </li>
+              <li>Area of interest and the content of your message</li>
+              <li>
+                Confirmation that you have read this Privacy Policy (required
+                to submit the form)
+              </li>
+            </ul>
+            <p className="mt-4 leading-relaxed font-medium text-white">
+              Technical information collected automatically:
+            </p>
+            <ul className="mt-2 list-disc space-y-2 pl-5">
+              <li>
+                IP address, browser and device signals, and request metadata
+                used for spam prevention and security
+              </li>
+              <li>
+                reCAPTCHA v3 risk signals provided by Google to help us
+                distinguish humans from bots
+              </li>
+              <li>
+                Standard web server logs generated by our hosting provider
+              </li>
+            </ul>
+            <p className="mt-4 leading-relaxed">
+              We do not use advertising cookies, analytics trackers, or
+              third-party marketing pixels on this website.
             </p>
           </section>
 
           <section>
-            <h2 className="text-xl font-semibold text-white">How the form is processed</h2>
+            <h2 className="text-xl font-semibold text-white">
+              4. Why we collect it and how we use it
+            </h2>
+            <ul className="mt-4 list-disc space-y-2 pl-5">
+              <li>
+                To respond to your inquiry and schedule an initial
+                conversation
+              </li>
+              <li>
+                To understand fit and route the request into Atlassian
+                Platform, BI and Analytics, or Automation and Integration
+              </li>
+              <li>
+                To prevent spam, fraud, and abuse of our website and email
+                channels
+              </li>
+              <li>
+                To maintain records of inquiries in case the conversation
+                becomes an engagement or a procurement process
+              </li>
+              <li>
+                To meet our legal, accounting, security, and operational
+                obligations
+              </li>
+            </ul>
             <p className="mt-4 leading-relaxed">
-              Contact form submissions are sent to leads@northlanterngroup.com. Members respond within one business day
-              in Canadian working hours.
+              We do not use the information you submit to train machine
+              learning models, and we do not sell personal information.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-white">
+              5. Consent and withdrawal of consent
+            </h2>
+            <p className="mt-4 leading-relaxed">
+              By submitting the contact form, you consent to NLG collecting
+              and using your information for the purposes described above.
+              You may withdraw consent at any time, subject to legal or
+              contractual restrictions and reasonable notice, by emailing{" "}
+              <a
+                href="mailto:privacy@northlanterngroup.com"
+                className="text-cyan-400 hover:text-cyan-300"
+              >
+                privacy@northlanterngroup.com
+              </a>
+              . Withdrawing consent may affect our ability to respond to
+              your inquiry.
+            </p>
+            <p className="mt-4 leading-relaxed">
+              We do not send unsolicited marketing email from this website.
+              If that changes, any commercial electronic messages will
+              comply with Canada&apos;s Anti-Spam Legislation (CASL),
+              including sender identification, a functioning unsubscribe
+              mechanism, and a valid physical address.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-white">
+              6. Service providers we rely on
+            </h2>
+            <p className="mt-4 leading-relaxed">
+              We use a small number of trusted service providers to operate
+              the website and the contact form. Each provider processes
+              personal information on our behalf, under contract, and only
+              for the limited purposes described below.
+            </p>
+            <ul className="mt-4 list-disc space-y-3 pl-5">
+              <li>
+                <span className="font-medium text-white">Vercel Inc.</span>{" "}
+                hosts this website and generates server logs used for
+                availability, security, and abuse prevention.
+              </li>
+              <li>
+                <span className="font-medium text-white">Resend</span>{" "}
+                delivers contact form submissions to our internal mailbox.
+              </li>
+              <li>
+                <span className="font-medium text-white">ZeroBounce</span>{" "}
+                checks that the email address you provide is deliverable,
+                to reduce bounced mail and form abuse.
+              </li>
+              <li>
+                <span className="font-medium text-white">
+                  Google reCAPTCHA v3
+                </span>{" "}
+                scores each form submission for bot-like behaviour. Google
+                may process the request IP and browser signals. Use is
+                governed by Google&apos;s{" "}
+                <a
+                  href="https://policies.google.com/privacy"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-cyan-400 hover:text-cyan-300"
+                >
+                  privacy policy
+                </a>{" "}
+                and{" "}
+                <a
+                  href="https://policies.google.com/terms"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-cyan-400 hover:text-cyan-300"
+                >
+                  terms of service
+                </a>
+                .
+              </li>
+              <li>
+                <span className="font-medium text-white">
+                  Google Workspace
+                </span>{" "}
+                stores our corporate email, including inquiries received
+                from the website.
+              </li>
+            </ul>
+            <p className="mt-4 leading-relaxed">
+              Additions and changes to this list will be reflected on this
+              page.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-white">
+              7. Where your information is processed
+            </h2>
+            <p className="mt-4 leading-relaxed">
+              Our service providers may store and process personal
+              information on servers located in Canada, the United States,
+              or other countries where they or their subprocessors operate.
+              When information is processed outside Canada, it may be
+              subject to the laws of those countries, including lawful
+              access requests by foreign authorities. We select providers
+              that commit to security and privacy standards consistent with
+              Canadian expectations, and we engage them under contractual
+              safeguards.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-white">
+              8. How long we keep it
+            </h2>
+            <p className="mt-4 leading-relaxed">
+              We retain personal information only as long as needed for the
+              purposes it was collected, or as required by law.
             </p>
             <ul className="mt-4 list-disc space-y-2 pl-5">
-              {serviceProviders.map((provider) => (
-                <li key={provider}>{provider}</li>
-              ))}
+              <li>
+                Contact form submissions that do not lead to an engagement
+                are retained for up to 24 months and then deleted or
+                anonymized.
+              </li>
+              <li>
+                Inquiries that become client engagements move into the
+                client file and are governed by the engagement agreement
+                and our standard business record retention practices.
+              </li>
+              <li>
+                Spam and abuse signals may be retained longer to protect
+                the integrity of our systems.
+              </li>
             </ul>
           </section>
 
           <section>
-            <h2 className="text-xl font-semibold text-white">Retention</h2>
+            <h2 className="text-xl font-semibold text-white">
+              9. How we protect your information
+            </h2>
             <p className="mt-4 leading-relaxed">
-              We keep inquiry data only as long as needed to respond, manage the relationship, and meet legal or
-              operational obligations. If the inquiry becomes an engagement, the relevant records move into the client
-              file.
+              We apply safeguards appropriate to the sensitivity of the
+              information, including HTTPS transport encryption, access
+              controls on internal mailboxes, least-privilege administrator
+              access, multi-factor authentication on supporting accounts,
+              and contracted obligations with our service providers. No
+              system is perfectly secure, and we do not promise absolute
+              security.
             </p>
           </section>
 
           <section>
-            <h2 className="text-xl font-semibold text-white">Access, correction, and deletion</h2>
+            <h2 className="text-xl font-semibold text-white">
+              10. Your rights
+            </h2>
             <p className="mt-4 leading-relaxed">
-              To request access, correction, or deletion of information submitted through the website, email
-              {" "}
-              <a href="mailto:leads@northlanterngroup.com" className="text-cyan-400 hover:text-cyan-300">
-                leads@northlanterngroup.com
+              Subject to applicable law, you may ask us to:
+            </p>
+            <ul className="mt-4 list-disc space-y-2 pl-5">
+              <li>Confirm whether we hold personal information about you</li>
+              <li>Provide access to that information</li>
+              <li>Correct information that is inaccurate or incomplete</li>
+              <li>Delete information we no longer need to retain</li>
+              <li>
+                Withdraw consent or unsubscribe from any future
+                communications
+              </li>
+              <li>Receive an explanation of our privacy practices</li>
+            </ul>
+            <p className="mt-4 leading-relaxed">
+              Send the request to{" "}
+              <a
+                href="mailto:privacy@northlanterngroup.com"
+                className="text-cyan-400 hover:text-cyan-300"
+              >
+                privacy@northlanterngroup.com
               </a>
-              . We will respond within one business day in Canadian working hours and route the request to the right
-              person.
+              . We will acknowledge the request within five business days
+              where practical and respond substantively within thirty days
+              unless more time is reasonably required. We may need to
+              verify your identity before acting on a request.
             </p>
           </section>
 
           <section>
-            <h2 className="text-xl font-semibold text-white">Updates</h2>
+            <h2 className="text-xl font-semibold text-white">
+              11. Complaints
+            </h2>
             <p className="mt-4 leading-relaxed">
-              We will update this page when the website data flow changes, including analytics, lead storage, or new
-              form processing tools.
+              If you believe we have handled your personal information
+              improperly, please contact the NLG Privacy Office first so we
+              can try to resolve the issue directly. You may also have the
+              right to contact the Office of the Privacy Commissioner of
+              Canada at{" "}
+              <a
+                href="https://www.priv.gc.ca"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-cyan-400 hover:text-cyan-300"
+              >
+                priv.gc.ca
+              </a>{" "}
+              or your provincial privacy regulator.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-white">
+              12. Changes to this policy
+            </h2>
+            <p className="mt-4 leading-relaxed">
+              We will update this page when our data handling changes,
+              including new service providers, new form processing tools,
+              or any introduction of analytics, tracking, or marketing
+              email. The date at the top of this page reflects the most
+              recent update. Material changes will be highlighted.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-white">
+              13. Contact us
+            </h2>
+            <p className="mt-4 leading-relaxed">
+              Privacy questions and requests:{" "}
+              <a
+                href="mailto:privacy@northlanterngroup.com"
+                className="text-cyan-400 hover:text-cyan-300"
+              >
+                privacy@northlanterngroup.com
+              </a>
+              <br />
+              General inquiries:{" "}
+              <a
+                href="mailto:hello@northlanterngroup.com"
+                className="text-cyan-400 hover:text-cyan-300"
+              >
+                hello@northlanterngroup.com
+              </a>
             </p>
           </section>
         </div>

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -16,5 +16,11 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: "yearly",
       priority: 0.3,
     },
+    {
+      url: "https://www.northlanterngroup.com/terms",
+      lastModified,
+      changeFrequency: "yearly",
+      priority: 0.3,
+    },
   ];
 }

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,0 +1,286 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Website Terms of Use | North Lantern Group",
+  description:
+    "Terms of use for the North Lantern Group Inc. website. Informational only. No professional advice or client relationship is created by visiting this site.",
+  alternates: {
+    canonical: "https://www.northlanterngroup.com/terms",
+  },
+};
+
+const LAST_UPDATED = "April 24, 2026";
+
+export default function TermsPage() {
+  return (
+    <main className="min-h-screen bg-neutral-950 text-white">
+      <section className="mx-auto max-w-3xl px-6 py-16 md:py-24">
+        <Link
+          href="/"
+          className="text-sm font-medium text-cyan-400 hover:text-cyan-300"
+        >
+          Back to North Lantern Group
+        </Link>
+
+        <div className="mt-10">
+          <p className="text-sm font-semibold uppercase tracking-[0.2em] text-cyan-400">
+            Website Terms of Use
+          </p>
+          <h1 className="mt-4 text-3xl md:text-5xl font-semibold tracking-tight">
+            Terms of use.
+          </h1>
+          <p className="mt-6 text-sm text-neutral-500">
+            Last updated: {LAST_UPDATED}
+          </p>
+          <p className="mt-6 text-neutral-400 leading-relaxed">
+            These terms govern your use of northlanterngroup.com, operated
+            by North Lantern Group Inc. (&quot;NLG,&quot; &quot;we,&quot;
+            &quot;us&quot;). By using this website you agree to these
+            terms. If you do not agree, please do not use the website.
+            These terms are not legal advice and do not replace any written
+            agreement between NLG and a client.
+          </p>
+        </div>
+
+        <div className="mt-10 space-y-10 text-neutral-300">
+          <section>
+            <h2 className="text-xl font-semibold text-white">
+              1. Informational use only
+            </h2>
+            <p className="mt-4 leading-relaxed">
+              The content on this website is provided for general
+              informational purposes only. It describes the services that
+              NLG offers and how we work. It is not professional, legal,
+              financial, tax, security, accounting, compliance,
+              architectural, or implementation advice for any specific
+              situation.
+            </p>
+            <p className="mt-4 leading-relaxed">
+              You should not act or refrain from acting on the basis of
+              anything on this website without obtaining advice appropriate
+              to your circumstances.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-white">
+              2. No engagement is created by visiting this site
+            </h2>
+            <p className="mt-4 leading-relaxed">
+              Visiting the website, reading our material, submitting the
+              contact form, exchanging introductory emails, or booking an
+              introductory call does not create a client relationship, a
+              contract of services, or any obligation on NLG to perform
+              work. A client engagement exists only when NLG and the
+              client have signed a written engagement agreement, statement
+              of work, or order form that expressly creates one.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-white">
+              3. No guarantee of outcomes
+            </h2>
+            <p className="mt-4 leading-relaxed">
+              The website describes our delivery model, practices, and
+              beliefs about how work should be done. It does not promise a
+              specific business, operational, financial, or performance
+              outcome. Any results described in connection with an
+              engagement depend on facts, inputs, and decisions that are
+              the client&apos;s responsibility and that are confirmed in
+              the engagement agreement rather than on the website.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-white">
+              4. Intellectual property
+            </h2>
+            <p className="mt-4 leading-relaxed">
+              The website, including its text, graphics, logos,
+              illustrations, icons, layout, and code, is owned by NLG or
+              its licensors and is protected by Canadian and international
+              intellectual property laws.
+            </p>
+            <p className="mt-4 leading-relaxed">
+              The North Lantern Group name, the NLG word mark, and the
+              stylized &quot;N&quot; lantern mark are trademarks of North
+              Lantern Group Inc. Third-party names and logos displayed on
+              this website belong to their respective owners and appear
+              only to identify the platforms and tools we work with.
+            </p>
+            <p className="mt-4 leading-relaxed">
+              You may view and share individual pages of the website for
+              your own non-commercial reference. You may not copy,
+              republish, distribute, modify, or create derivative works
+              from the website without our prior written permission, except
+              as permitted by applicable law.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-white">
+              5. Permitted and prohibited uses
+            </h2>
+            <p className="mt-4 leading-relaxed">You agree not to:</p>
+            <ul className="mt-4 list-disc space-y-2 pl-5">
+              <li>
+                Use the website in a way that violates any applicable law
+                or regulation
+              </li>
+              <li>
+                Submit false, misleading, defamatory, or infringing
+                information through the contact form
+              </li>
+              <li>
+                Attempt to probe, scan, or test the vulnerability of the
+                website or circumvent any security or authentication
+                measures
+              </li>
+              <li>
+                Interfere with the availability of the website or with
+                other users&apos; ability to access it
+              </li>
+              <li>
+                Use automated systems to scrape content at a scale that
+                degrades service, or to bypass the reCAPTCHA and related
+                anti-spam protections
+              </li>
+              <li>
+                Impersonate any person or organization when submitting
+                information
+              </li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-white">
+              6. Third-party services and links
+            </h2>
+            <p className="mt-4 leading-relaxed">
+              The website relies on third-party services, including a
+              hosting provider, an email delivery provider, an email
+              validation provider, an anti-bot service, and corporate email
+              infrastructure. Links to external websites, including our
+              LinkedIn page and third-party documentation, are provided for
+              convenience. NLG does not control and is not responsible for
+              the content, policies, or practices of third-party services
+              or websites. Visiting them is at your own risk and subject to
+              their own terms and privacy policies.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-white">
+              7. Disclaimers
+            </h2>
+            <p className="mt-4 leading-relaxed">
+              The website is provided on an &quot;as is&quot; and &quot;as
+              available&quot; basis. To the fullest extent permitted by
+              law, NLG disclaims all express and implied warranties in
+              respect of the website, including implied warranties of
+              merchantability, fitness for a particular purpose, and
+              non-infringement. We do not warrant that the website will be
+              uninterrupted, error-free, secure, or free of harmful
+              components, or that the information on it is current,
+              complete, or correct for your specific situation.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-white">
+              8. Limitation of liability
+            </h2>
+            <p className="mt-4 leading-relaxed">
+              To the maximum extent permitted by law, NLG and its
+              directors, officers, employees, contractors, and agents will
+              not be liable for any indirect, incidental, special,
+              consequential, punitive, or exemplary damages, or for any
+              loss of profits, revenue, data, goodwill, or business
+              opportunity, arising out of or relating to your use of this
+              website, even if advised of the possibility of such damages.
+              Nothing in these terms limits or excludes any liability that
+              cannot be limited or excluded under applicable law. Our total
+              liability arising out of or relating to your use of this
+              website is limited to the greater of CAD $100 or the amount
+              actually paid by you to NLG (if any) for access to the
+              website in the twelve months before the claim arose. This
+              section does not affect the terms of any separate written
+              engagement agreement between NLG and a client, which governs
+              liability for services.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-white">
+              9. Indemnity
+            </h2>
+            <p className="mt-4 leading-relaxed">
+              You agree to indemnify and hold NLG harmless from third-party
+              claims, losses, and expenses, including reasonable legal
+              fees, arising out of your breach of these terms, your misuse
+              of the website, or your violation of applicable law in
+              connection with the website.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-white">
+              10. Changes to these terms
+            </h2>
+            <p className="mt-4 leading-relaxed">
+              We may update these terms from time to time. The &quot;last
+              updated&quot; date at the top of this page reflects the most
+              recent version. Continued use of the website after an update
+              means you accept the updated terms. Material changes will be
+              highlighted.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-white">
+              11. Governing law
+            </h2>
+            <p className="mt-4 leading-relaxed">
+              These terms are governed by the laws of the Province of
+              Ontario and the federal laws of Canada applicable in Ontario,
+              without regard to conflict of law rules. Subject to
+              applicable law, the courts located in Ottawa, Ontario have
+              jurisdiction over any dispute arising out of or relating to
+              these terms or your use of the website.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-white">
+              12. Contact
+            </h2>
+            <p className="mt-4 leading-relaxed">
+              Questions about these terms:{" "}
+              <a
+                href="mailto:hello@northlanterngroup.com"
+                className="text-cyan-400 hover:text-cyan-300"
+              >
+                hello@northlanterngroup.com
+              </a>
+              <br />
+              Privacy questions:{" "}
+              <a
+                href="mailto:privacy@northlanterngroup.com"
+                className="text-cyan-400 hover:text-cyan-300"
+              >
+                privacy@northlanterngroup.com
+              </a>
+            </p>
+            <p className="mt-4 leading-relaxed">
+              North Lantern Group Inc.
+              <br />
+              400 Slater St., Ottawa, ON K1R 7S7, Canada
+            </p>
+          </section>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/components/sections/Contact.tsx
+++ b/src/components/sections/Contact.tsx
@@ -38,6 +38,7 @@ const ContactForm = memo(function ContactForm() {
   const [selectedCountry, setSelectedCountry] = useState<Country>("CA");
   const [emailError, setEmailError] = useState("");
   const [privacyAccepted, setPrivacyAccepted] = useState(false);
+  const [marketingConsent, setMarketingConsent] = useState(false);
   const [honeypot, setHoneypot] = useState("");
 
   const { executeRecaptcha } = useGoogleReCaptcha();
@@ -107,6 +108,7 @@ const ContactForm = memo(function ContactForm() {
           phone: phoneValue,
           captchaToken,
           website: honeypot,
+          marketingConsent,
         }),
       });
       const data = await response.json();
@@ -124,6 +126,7 @@ const ContactForm = memo(function ContactForm() {
         });
         setPhoneValue(undefined);
         setPrivacyAccepted(false);
+        setMarketingConsent(false);
       } else {
         setFormStatus("error");
         setFormMessage(data.error || "Something went wrong. Please try again.");
@@ -286,8 +289,26 @@ const ContactForm = memo(function ContactForm() {
             onChange={(e) => setPrivacyAccepted(e.target.checked)}
           />
           <span>
-            {"I have read the North Lantern Group "}
-            <a href="/privacy">privacy statement</a>. <span className="nlg-req">*</span>
+            I have read the North Lantern Group{" "}
+            <a href="/privacy">Privacy Policy</a> and{" "}
+            <a href="/terms">Terms of Use</a>, and I consent to NLG
+            processing the information I submit here to respond to my
+            inquiry. <span className="nlg-req">*</span>
+          </span>
+        </label>
+      </div>
+
+      <div className="nlg-field nlg-privacy">
+        <label>
+          <input
+            type="checkbox"
+            checked={marketingConsent}
+            onChange={(e) => setMarketingConsent(e.target.checked)}
+          />
+          <span>
+            Optional: I would like to receive occasional NLG updates about
+            Atlassian, BI, and automation practice. I can unsubscribe at any
+            time.
           </span>
         </label>
       </div>
@@ -319,8 +340,29 @@ const ContactForm = memo(function ContactForm() {
       </button>
 
       <p className="nlg-form-captcha-note">
-        Protected by invisible reCAPTCHA v3. By submitting, you agree to Google&apos;s
-        terms and our privacy statement.
+        This form is protected by invisible Google reCAPTCHA v3 and uses
+        ZeroBounce to validate email addresses. Use is subject to
+        Google&apos;s{" "}
+        <a
+          href="https://policies.google.com/privacy"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          privacy policy
+        </a>{" "}
+        and{" "}
+        <a
+          href="https://policies.google.com/terms"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          terms of service
+        </a>
+        . For privacy questions, email{" "}
+        <a href="mailto:privacy@northlanterngroup.com">
+          privacy@northlanterngroup.com
+        </a>
+        .
       </p>
     </form>
   );

--- a/src/components/sections/Footer.tsx
+++ b/src/components/sections/Footer.tsx
@@ -72,7 +72,13 @@ export default function Footer() {
         </div>
         <div className="nlg-legal">
           <span>
-            North Lantern Group Inc. · Ontario, Canada · <a href="/privacy">Privacy</a> · © 2026
+            North Lantern Group Inc. · Ontario, Canada ·{" "}
+            <a href="/privacy">Privacy</a> · <a href="/terms">Terms</a> ·
+            Privacy requests:{" "}
+            <a href="mailto:privacy@northlanterngroup.com">
+              privacy@northlanterngroup.com
+            </a>{" "}
+            · © 2026
           </span>
           <span>hello@northlanterngroup.com</span>
         </div>


### PR DESCRIPTION
## Summary

- **Privacy Policy**: upgraded `/privacy` to a PIPEDA-aligned 13-section policy — NLG Privacy Office contact, last-updated date, data types, purposes, consent + withdrawal, service providers (Vercel, Resend, ZeroBounce, Google reCAPTCHA, Google Workspace), cross-border processing, retention, safeguards, rights, complaints incl. OPC escalation, CASL language, "we do not sell personal information".
- **Terms of Use**: new `/terms` covering informational-only use, no engagement created by visiting, no outcome guarantees, IP/trademarks, prohibited uses, disclaimers, limitation of liability (CAD $100 cap that does not override engagement agreements), indemnity, governing law (Ontario).
- **Contact form**: links both `/privacy` and `/terms` before submission; adds a separate optional, unchecked-by-default marketing consent checkbox (CASL express-consent capture, not bundled with service consent); publishes `privacy@northlanterngroup.com` as the privacy contact in the form footer. API forwards the `marketingConsent` flag into the internal submission email.
- **Footer**: adds `/terms` and `mailto:privacy@northlanterngroup.com` alongside existing `/privacy`.
- **Sitemap**: adds `/terms`.
- **Security headers**: adds `Content-Security-Policy-Report-Only` scoped to `'self'` + Google reCAPTCHA endpoints, `X-Frame-Options: SAMEORIGIN`, `Cross-Origin-Opener-Policy: same-origin`, extends `Permissions-Policy` with `interest-cohort=()`.
- **Compliance artifacts**: new `docs/compliance/` folder with the master checklist, privacy request workflow runbook, and README. Internal-only working documents.

No claim is made that NLG is "fully compliant," "certified," or "legally approved." Items requiring legal counsel review are listed in `docs/compliance/website-compliance-checklist.md` §12.

## Test plan

- [x] `npm run lint` passes (no warnings or errors)
- [x] `npm run build` passes (10/10 static pages; `/privacy` and `/terms` prerendered)
- [x] `npm audit --omit=dev`: 3 moderate transitive advisories documented in checklist §2.15 (low runtime exposure)
- [x] `privacy@northlanterngroup.com` used consistently across Privacy, Terms, Footer, Contact form; `leads@` only appears as the internal API route recipient
- [x] No broken `href="#"` legal links, no overclaiming language in public copy
- [ ] Post-merge: verify live `/privacy`, `/terms`, footer links, sitemap, and response headers on production
- [ ] Provision `privacy@northlanterngroup.com` Google Workspace group (2+ admins) before public launch
- [ ] Circulate checklist §12 (open questions) to legal counsel for review

🤖 Generated with [Claude Code](https://claude.com/claude-code)