### PR TITLE
WEB-47: Pre-launch polish — Cal.com CTAs, fix anchors, copy cleanup

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import NLGLogo from "@/components/brand/NLGLogo";
+import { BOOKING_URL } from "@/config/site";
 
 export default function Header() {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
@@ -41,7 +42,12 @@ export default function Header() {
           <a className="nlg-btn nlg-btn-ghost" href="#contact">
             Contact
           </a>
-          <a className="nlg-btn nlg-btn-primary" href="#contact" data-note="cal.com-pending">
+          <a
+            className="nlg-btn nlg-btn-primary"
+            href={BOOKING_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             Book a call
           </a>
           <button
@@ -87,10 +93,11 @@ export default function Header() {
               </li>
               <li className="nlg-mobile-cta">
                 <a
-                  href="#contact"
+                  href={BOOKING_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
                   onClick={() => setMobileMenuOpen(false)}
                   className="nlg-btn nlg-btn-primary"
-                  data-note="cal.com-pending"
                 >
                   Book a call
                 </a>

--- a/src/components/sections/Contact.tsx
+++ b/src/components/sections/Contact.tsx
@@ -9,6 +9,7 @@ import flags from "react-phone-number-input/flags";
 import "react-phone-number-input/style.css";
 import { GoogleReCaptchaProvider, useGoogleReCaptcha } from "react-google-recaptcha-v3";
 import { IconArrow, IconCalendar, IconLinkedIn, IconMail } from "@/components/icons/PracticeIcons";
+import { BOOKING_URL, LINKEDIN_URL, EMAIL_GENERAL } from "@/config/site";
 
 function getPhoneFormatHint(country: Country | undefined): string {
   if (!country) return "";
@@ -380,15 +381,20 @@ function Contact() {
             </span>
           </h2>
           <div className="nlg-contact-alt">
-            <a className="nlg-btn nlg-btn-primary nlg-btn-lg" href="#contact" data-note="cal.com-pending">
+            <a
+              className="nlg-btn nlg-btn-primary nlg-btn-lg"
+              href={BOOKING_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
               <IconCalendar size={16} /> Book a call
             </a>
-            <a className="nlg-text-link" href="mailto:hello@northlanterngroup.com">
+            <a className="nlg-text-link" href={`mailto:${EMAIL_GENERAL}`}>
               <IconMail size={14} /> Email us directly <IconArrow size={14} />
             </a>
             <a
               className="nlg-text-link"
-              href="https://www.linkedin.com/company/northlanterngroup/"
+              href={LINKEDIN_URL}
               target="_blank"
               rel="noopener noreferrer"
             >

--- a/src/components/sections/Footer.tsx
+++ b/src/components/sections/Footer.tsx
@@ -65,7 +65,7 @@ export default function Footer() {
             <h4>Writing</h4>
             <ul>
               <li>
-                <span className="nlg-placeholder">Index pending first essay</span>
+                <a href="#writing">Essays coming 2026</a>
               </li>
             </ul>
           </div>

--- a/src/components/sections/HeroV2.tsx
+++ b/src/components/sections/HeroV2.tsx
@@ -2,6 +2,7 @@
 
 import dynamic from "next/dynamic";
 import { IconArrow } from "@/components/icons/PracticeIcons";
+import { BOOKING_URL } from "@/config/site";
 
 const OperationsConsole = dynamic(() => import("@/components/OperationsConsole"), {
   ssr: false,
@@ -32,7 +33,12 @@ export default function HeroV2() {
           </p>
 
           <div className="nlg-hero-actions">
-            <a className="nlg-btn nlg-btn-primary nlg-btn-lg" href="#cta" data-note="cal.com-pending">
+            <a
+              className="nlg-btn nlg-btn-primary nlg-btn-lg"
+              href={BOOKING_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
               Book a call <IconArrow size={16} />
             </a>
             <a className="nlg-btn nlg-btn-secondary nlg-btn-lg" href="#how-we-work">

--- a/src/components/sections/HowWeWork.tsx
+++ b/src/components/sections/HowWeWork.tsx
@@ -53,8 +53,8 @@ export default function HowWeWork() {
         </p>
 
         <div className="nlg-steps-link">
-          <a className="nlg-text-link" href="#cta">
-            Full engagement model <IconArrow size={14} />
+          <a className="nlg-text-link" href="#contact">
+            Start a conversation <IconArrow size={14} />
           </a>
         </div>
       </div>

--- a/src/components/sections/Practices.tsx
+++ b/src/components/sections/Practices.tsx
@@ -90,7 +90,8 @@ export default function Practices() {
               <article
                 className="nlg-practice-card nlg-reveal"
                 key={p.id}
-                style={{ transitionDelay: `${i * 60}ms` }}
+                id={p.id}
+                style={{ transitionDelay: `${i * 60}ms`, scrollMarginTop: "96px" }}
               >
                 <span className="nlg-practice-num" aria-hidden="true">
                   {num}
@@ -110,7 +111,7 @@ export default function Practices() {
                   <div className="nlg-constraint-eyebrow">CONSTRAINT</div>
                   <p className="nlg-practice-refusal">{p.refusal}</p>
                 </div>
-                <a className="nlg-practice-link" href={`#${p.id}`}>
+                <a className="nlg-practice-link" href="#contact">
                   {p.cta} <IconArrow size={14} />
                 </a>
               </article>

--- a/src/components/sections/Writing.tsx
+++ b/src/components/sections/Writing.tsx
@@ -49,7 +49,7 @@ export default function Writing() {
               <p className="nlg-essay-teaser">{e.teaser}</p>
               <div className="nlg-essay-footer">
                 <span>ESSAY.0{i + 1}</span>
-                <span aria-hidden="true">· draft</span>
+                <span aria-hidden="true">· in progress</span>
               </div>
             </article>
           ))}

--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -1,0 +1,12 @@
+// Single source of truth for outbound links referenced from the marketing
+// site. Keep values here so a change to a vendor, domain, or handle is a
+// one-line edit instead of a codebase-wide search.
+
+export const BOOKING_URL =
+  "https://cal.com/northlanterngroup/book-a-call" as const;
+
+export const LINKEDIN_URL =
+  "https://www.linkedin.com/company/northlanterngroup/" as const;
+
+export const EMAIL_GENERAL = "hello@northlanterngroup.com" as const;
+export const EMAIL_PRIVACY = "privacy@northlanterngroup.com" as const;


### PR DESCRIPTION
## Summary

Pre-launch production-readiness pass. Wires the real Cal.com booking URL, fixes every broken internal anchor, and removes weak "draft" copy that would undermine launch credibility.

- **Cal.com integration**: new `src/config/site.ts` holds `BOOKING_URL = https://cal.com/northlanterngroup/book-a-call`. All four "Book a call" CTAs now point to Cal.com and open in a new tab with `rel="noopener noreferrer"` (Header desktop, Header mobile menu, Hero primary, Contact section). All `data-note="cal.com-pending"` markers removed.
- **Broken anchors fixed**:
  - Added `id={p.id}` + `scroll-margin-top` to each Practices card so Footer `#atlassian` / `#bi` / `#automation` anchor to the right card under the sticky header.
  - Changed each practice card's own CTA from `#${p.id}` (self-reference, no-op) to `#contact`.
  - Replaced `#cta` (nonexistent anchor) with `#contact` in HowWeWork; relabelled "Full engagement model" → "Start a conversation" so the copy matches the destination.
- **Launch polish**: Writing card footers show "· in progress" instead of "· draft". Footer Writing column links to `#writing` ("Essays coming 2026") instead of "Index pending first essay".

## Verification before merging

- `npm run lint`: no warnings or errors
- `npm run build`: passes (10/10 static pages prerendered)
- Local prod server: `/`, `/privacy`, `/terms`, `/sitemap.xml`, `/robots.txt` all 200
- Cal.com URL appears 3× in SSR HTML (header desktop, hero, contact); mobile menu binds on open
- All 8 remaining internal hash anchors (`#atlassian`, `#automation`, `#belief`, `#bi`, `#contact`, `#how-we-work`, `#practices`, `#writing`) now resolve to a rendered `id`
- No `#cta`, no `cal.com-pending`, no "· draft", no "TODO/FIXME/coming soon" placeholder copy in `src/`
- No compliance regressions: `/privacy`, `/terms`, the marketing-consent checkbox, reCAPTCHA/ZeroBounce disclosure, and the `privacy@northlanterngroup.com` contact are untouched

## Test plan

- [x] Lint + build pass locally
- [x] Local link integrity: every hash link has a matching rendered `id`
- [ ] Vercel preview deploy passes
- [ ] Visual QA on preview: desktop + mobile, all four Book-a-call CTAs open Cal.com in a new tab, Footer anchors scroll to the right Practice card with header clearance
- [ ] Post-merge: production routes return 200 and homepage contains 3× Cal.com link in SSR

## Notes

- Cal.com is an outbound link (not an embed), so the existing report-only CSP does not need updating. CSP stays in report-only mode.
- Pre-existing untracked `AGENTS.md` at repo root is intentionally not staged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)