### PR TITLE
Fix testimonial auto-cycle scroll jump

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1673,6 +1673,7 @@ button { font: inherit; color: inherit; background: none; border: 0; cursor: poi
   text-transform: uppercase;
 }
 .nlg-attestation-roster-list {
+  position: relative;
   flex: 1 1 auto;
   min-height: 0;
   overflow-y: auto;

--- a/src/components/sections/Testimonials.tsx
+++ b/src/components/sections/Testimonials.tsx
@@ -306,6 +306,8 @@ function renderHighlightedQuote(fullQuote: string, pullQuote: string) {
   );
 }
 
+type TransitionSource = "auto" | "dot" | "roster" | "keyboard";
+
 export default function Testimonials() {
   const reducedMotion = useReducedMotion();
   const panelRef = useRef<HTMLElement | null>(null);
@@ -318,6 +320,7 @@ export default function Testimonials() {
   const [activeIndex, setActiveIndex] = useState(0);
   const [displayIndex, setDisplayIndex] = useState(0);
   const [isPaused, setIsPaused] = useState(false);
+  const [isVisible, setIsVisible] = useState(false);
   const [phase, setPhase] = useState<"idle" | "out" | "decode">("decode");
 
   const displayed = getAttestation(displayIndex);
@@ -349,18 +352,22 @@ export default function Testimonials() {
     }
   }, []);
 
-  const scrollRosterToActive = useCallback((index: number) => {
+  // Scrolls only the roster container — never walks ancestors, never moves the document.
+  // No-op for `auto` source so the 7s auto-cycle cannot pull the viewport.
+  const scrollRosterToActive = useCallback((index: number, source: TransitionSource) => {
+    if (source === "auto") return;
     const roster = rosterRef.current;
     const row = rosterButtonRefs.current[index];
     if (!roster || !row) return;
 
     const behavior: ScrollBehavior = reducedMotion ? "auto" : "smooth";
+    const gutter = 12;
+
     if (window.matchMedia("(max-width: 767px)").matches) {
       const rowLeft = row.offsetLeft;
       const rowRight = rowLeft + row.offsetWidth;
       const viewLeft = roster.scrollLeft;
       const viewRight = viewLeft + roster.clientWidth;
-      const gutter = 12;
 
       if (rowLeft < viewLeft) {
         roster.scrollTo({ left: Math.max(0, rowLeft - gutter), behavior });
@@ -370,14 +377,21 @@ export default function Testimonials() {
       return;
     }
 
-    row.scrollIntoView({
-      block: "nearest",
-      inline: "nearest",
-      behavior,
-    });
+    const rowTop = row.offsetTop;
+    const rowBottom = rowTop + row.offsetHeight;
+    const viewTop = roster.scrollTop;
+    const viewBottom = viewTop + roster.clientHeight;
+
+    if (rowTop < viewTop) {
+      roster.scrollTo({ top: Math.max(0, rowTop - gutter), behavior });
+    } else if (rowBottom > viewBottom) {
+      roster.scrollTo({ top: rowBottom - roster.clientHeight + gutter, behavior });
+    }
   }, [reducedMotion]);
 
-  const scrollPrimaryIntoView = useCallback(() => {
+  // Mobile-only convenience after explicit user activation; never on auto-cycle.
+  const scrollPrimaryIntoView = useCallback((source: TransitionSource) => {
+    if (source === "auto") return;
     const primary = primaryRef.current;
     if (!primary || !window.matchMedia("(max-width: 767px)").matches) return;
 
@@ -388,18 +402,21 @@ export default function Testimonials() {
     });
   }, [reducedMotion]);
 
-  const runTransition = useCallback((nextIndex: number, revealPrimary = false) => {
+  const runTransition = useCallback((nextIndex: number, source: TransitionSource) => {
     const next = mod(nextIndex, ATTESTATIONS.length);
     if (next === activeIndex) return;
 
     clearTransitionTimers();
+    const userInitiated = source !== "auto";
 
     if (reducedMotion) {
       setActiveIndex(next);
       setDisplayIndex(next);
       setPhase("decode");
-      scrollRosterToActive(next);
-      if (revealPrimary) window.requestAnimationFrame(scrollPrimaryIntoView);
+      if (userInitiated) {
+        scrollRosterToActive(next, source);
+        if (source !== "keyboard") scrollPrimaryIntoView(source);
+      }
       return;
     }
 
@@ -410,8 +427,10 @@ export default function Testimonials() {
       window.setTimeout(() => {
         setDisplayIndex(next);
         setPhase("decode");
-        scrollRosterToActive(next);
-        if (revealPrimary) scrollPrimaryIntoView();
+        if (userInitiated) {
+          scrollRosterToActive(next, source);
+          if (source !== "keyboard") scrollPrimaryIntoView(source);
+        }
       }, 260),
     );
   }, [activeIndex, clearTransitionTimers, reducedMotion, scrollPrimaryIntoView, scrollRosterToActive]);
@@ -426,13 +445,35 @@ export default function Testimonials() {
     resumeTimerRef.current = window.setTimeout(() => setIsPaused(false), 1500);
   }, []);
 
+  // Pause auto-cycle when the section is not meaningfully on screen,
+  // so a 7s timer cannot fire while the visitor is reading something else.
+  useEffect(() => {
+    const node = panelRef.current;
+    if (!node || typeof IntersectionObserver === "undefined") {
+      setIsVisible(true);
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const entry = entries[0];
+        if (!entry) return;
+        setIsVisible(entry.intersectionRatio >= 0.3);
+      },
+      { threshold: [0, 0.1, 0.2, 0.3, 0.5, 0.75, 1] },
+    );
+
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, []);
+
   useEffect(() => {
     clearAutoTimer();
-    if (!isPaused) {
-      autoTimerRef.current = window.setTimeout(() => runTransition(activeIndex + 1), 7000);
+    if (!isPaused && isVisible) {
+      autoTimerRef.current = window.setTimeout(() => runTransition(activeIndex + 1, "auto"), 7000);
     }
     return clearAutoTimer;
-  }, [activeIndex, clearAutoTimer, isPaused, runTransition]);
+  }, [activeIndex, clearAutoTimer, isPaused, isVisible, runTransition]);
 
   useEffect(() => () => {
     clearAutoTimer();
@@ -443,15 +484,19 @@ export default function Testimonials() {
   const handleRosterKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>, index: number) => {
     if (event.key === "ArrowDown" || event.key === "ArrowRight") {
       event.preventDefault();
-      rosterButtonRefs.current[mod(index + 1, ATTESTATIONS.length)]?.focus();
+      const nextIdx = mod(index + 1, ATTESTATIONS.length);
+      rosterButtonRefs.current[nextIdx]?.focus({ preventScroll: true });
+      scrollRosterToActive(nextIdx, "keyboard");
     }
     if (event.key === "ArrowUp" || event.key === "ArrowLeft") {
       event.preventDefault();
-      rosterButtonRefs.current[mod(index - 1, ATTESTATIONS.length)]?.focus();
+      const prevIdx = mod(index - 1, ATTESTATIONS.length);
+      rosterButtonRefs.current[prevIdx]?.focus({ preventScroll: true });
+      scrollRosterToActive(prevIdx, "keyboard");
     }
     if (event.key === "Enter" || event.key === " ") {
       event.preventDefault();
-      runTransition(index, true);
+      runTransition(index, "keyboard");
     }
     if (event.key === "Escape") {
       event.currentTarget.blur();
@@ -493,7 +538,7 @@ export default function Testimonials() {
                   data-active={index === activeIndex}
                   data-tooltip={`${attestation.practiceArea} // ${attestation.name}`}
                   key={attestation.id}
-                  onClick={() => runTransition(index, true)}
+                  onClick={() => runTransition(index, "dot")}
                   role="tab"
                   type="button"
                 />
@@ -543,7 +588,7 @@ export default function Testimonials() {
                   className="nlg-attestation-row"
                   data-active={index === activeIndex}
                   key={attestation.id}
-                  onClick={() => runTransition(index, true)}
+                  onClick={() => runTransition(index, "roster")}
                   onKeyDown={(event) => handleRosterKeyDown(event, index)}
                   ref={(node) => {
                     rosterButtonRefs.current[index] = node;


### PR DESCRIPTION
## Summary
- The Attestation Console (`#work`) was pulling the document toward itself every 7s via `row.scrollIntoView` during automatic transitions. A visitor stopped on the Belief/Practices section above `#work` saw the page jerk downward without input. This PR removes all document-moving scroll behavior from the auto-cycle.
- Split `runTransition` by source (`auto` | `dot` | `roster` | `keyboard`). Auto-cycle never invokes any document-affecting scroll. Roster alignment now uses manual `roster.scrollTop` / `roster.scrollLeft` math on the roster container only — never `scrollIntoView` on a row.
- Added an `IntersectionObserver` guard so the 7s timer pauses while `#work` is less than 30% on screen, and resumes only when the section is visible and not hovered/focused. Keyboard arrow nav uses `focus({ preventScroll: true })` plus internal roster scroll, so even keyboard navigation no longer moves the document.

## Behavior preserved
- Hover/focus pause, reduced-motion gating, dot click, roster click, keyboard Enter/Space selection, mobile primary-into-view on explicit user activation.
- Visual design is unchanged.

## Verification
Local production build (`npm run build && npm run start`), idle-scroll test scripted with Playwright, viewport positioned with `#work` 200px below the fold (the exact bug-trigger condition):

| viewport | startY | endY (after 22s) | delta |
| --- | --- | --- | --- |
| desktop 1440x900 | 2752 | 2752 | 0 |
| desktop 1920x1080 | 2572 | 2572 | 0 |
| mobile 375x812 | 5522 | 5522 | 0 |
| mobile 414x896 | 4865 | 4865 | 0 |
| tablet 768x1024 | 3730 | 3730 | 0 |
| `/#work` direct | 3740 | 3740 | 0 (active dot did advance from 0→3 — content cycled, page did not) |
| reduced-motion | 2740 | 2740 | 0 |

- `npm run lint` — clean.
- `npm run build` — succeeds; static pages 10/10.
- `git diff --check` — clean.
- `npm audit --omit=dev` — 5 pre-existing moderate advisories (`postcss<8.5.10` via `next`; `uuid<14` via `svix`/`resend`). All require `npm audit fix --force` (breaking). Out of scope here; tracked in WEB-42.

## Test plan
- [ ] Open `https://www.northlanterngroup.com/`, scroll to the Belief/Practices area near "NLG rebuilds the operational layer underneath…", wait 25s — `window.scrollY` stays put.
- [ ] Repeat at 1440x900, 1920x1080, 375x812, 414x896, 768x1024.
- [ ] Open `/#work` directly — browser lands on the section, no further auto-scroll afterward.
- [ ] Click testimonial dots and roster rows — selection still switches.
- [ ] Keyboard: tab into a roster row, ArrowDown / ArrowUp / Enter — focus moves and the active testimonial changes without the document jumping.
- [ ] Enable system reduced-motion — no decode/typewriter animation, no scroll jumps.
- [ ] No console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)