### PR TITLE
WEB-54: Harden /api/contact against abuse

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,11 @@ ZEROBOUNCE_API_KEY=your_zerobounce_api_key_here
 NEXT_PUBLIC_RECAPTCHA_SITE_KEY=your_recaptcha_site_key_here
 RECAPTCHA_SECRET_KEY=your_recaptcha_secret_key_here
 
+# Upstash Redis - Contact form rate limiting
+UPSTASH_REDIS_REST_URL=https://your-upstash-redis-url.upstash.io
+UPSTASH_REDIS_REST_TOKEN=your_upstash_redis_rest_token_here
+CONTACT_RATE_LIMIT_ENABLED=true
+
 # Optional Google Sheets lead backup via Google Apps Script Web App
 # Keep disabled until the Apps Script endpoint and HMAC secret are configured.
 LEAD_BACKUP_ENABLED=false

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "north-lantern-group",
       "version": "0.1.0",
       "dependencies": {
+        "@upstash/ratelimit": "^2.0.8",
+        "@upstash/redis": "^1.37.0",
         "cobe": "^2.0.1",
         "framer-motion": "^12.38.0",
         "lucide-react": "^0.554.0",
@@ -16,7 +18,8 @@
         "react-dom": "^18.3.1",
         "react-google-recaptcha-v3": "^1.11.0",
         "react-phone-number-input": "^3.4.14",
-        "resend": "^6.5.2"
+        "resend": "^6.5.2",
+        "zod": "^3.25.76"
       },
       "devDependencies": {
         "@types/node": "^20",
@@ -27,7 +30,8 @@
         "eslint-config-next": "^15.5.15",
         "postcss": "^8.4.49",
         "tailwindcss": "^3.4.17",
-        "typescript": "5.9.3"
+        "typescript": "5.9.3",
+        "vitest": "^4.1.5"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -42,31 +46,104 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.7.1.tgz",
-      "integrity": "sha512-o1uhUASyo921r2XtHYOHy7gdkGLge8ghBEQHMWmyJFoXlpU58kIrhhN3w26lpQb6dspetweapMn2CSNwQ8I4wg==",
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
       "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.1.0",
+        "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.7.1.tgz",
-      "integrity": "sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
-      "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
@@ -867,6 +944,299 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@oxc-project/types": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
+      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
+      "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
+      "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
+      "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -883,6 +1253,13 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
       "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@swc/helpers": {
@@ -903,6 +1280,31 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
@@ -1458,6 +1860,185 @@
         "win32"
       ]
     },
+    "node_modules/@upstash/core-analytics": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@upstash/core-analytics/-/core-analytics-0.0.10.tgz",
+      "integrity": "sha512-7qJHGxpQgQr9/vmeS1PktEwvNAF7TI4iJDi8Pu2CFZ9YUGHZH4fOP5TfYlZ4aVxfopnELiE4BS4FBjyK7V1/xQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@upstash/redis": "^1.28.3"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@upstash/ratelimit": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@upstash/ratelimit/-/ratelimit-2.0.8.tgz",
+      "integrity": "sha512-YSTMBJ1YIxsoPkUMX/P4DDks/xV5YYCswWMamU8ZIfK9ly6ppjRnVOyBhMDXBmzjODm4UQKcxsJPvaeFAijp5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@upstash/core-analytics": "^0.0.10"
+      },
+      "peerDependencies": {
+        "@upstash/redis": "^1.34.3"
+      }
+    },
+    "node_modules/@upstash/redis": {
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.37.0.tgz",
+      "integrity": "sha512-LqOJ3+XWPLSZ2rGSed5DYG3ixybxb8EhZu3yQqF7MdZX1wLBG/FRcI6xcUZXHy/SS7mmXWyadrud0HJHkOc+uw==",
+      "license": "MIT",
+      "dependencies": {
+        "uncrypto": "^0.1.3"
+      }
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.5.tgz",
+      "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.5",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.5",
+        "vitest": "4.1.5"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.5",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.5",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -1712,11 +2293,44 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
       "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
       "dev": true
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
+      "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/async-function": {
       "version": "1.0.0",
@@ -1964,6 +2578,16 @@
         }
       ]
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2065,6 +2689,13 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/country-flag-icons": {
       "version": "1.6.4",
@@ -2222,8 +2853,8 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -2390,6 +3021,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -2884,6 +3522,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2891,6 +3539,16 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -3381,6 +4039,15 @@
       "dependencies": {
         "react-is": "^16.7.0"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -3877,6 +4544,51 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
@@ -4011,6 +4723,267 @@
       "integrity": "sha512-P2aLrbeqHbmh8+9P35LXQfXOKc7XJ0ymUKl7tyeyQjdRNfzunXWxQXGc4yl3fUf28fqLRfPY+vIVvFXK7KEBTw==",
       "license": "MIT"
     },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/lilconfig": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
@@ -4068,6 +5041,48 @@
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/math-intrinsics": {
@@ -4419,6 +5434,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -4537,6 +5563,13 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -4589,9 +5622,9 @@
       "license": "MIT-0"
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "dev": true,
       "funding": [
         {
@@ -4607,6 +5640,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -4996,6 +6030,40 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
+      "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.127.0",
+        "@rolldown/pluginutils": "1.0.0-rc.17"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -5275,6 +6343,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -5289,6 +6364,13 @@
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
       "dev": true
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/standardwebhooks": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
@@ -5298,6 +6380,13 @@
         "@stablelib/base64": "^1.0.0",
         "fast-sha256": "^1.3.0"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -5622,14 +6711,32 @@
         "node": ">=0.8"
       }
     },
-    "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -5666,6 +6773,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -5845,6 +6962,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/uncrypto": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
@@ -5941,6 +7064,200 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.0.10",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
+      "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.10",
+        "rolldown": "1.0.0-rc.17",
+        "tinyglobby": "^0.2.16"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/which": {
@@ -6043,6 +7360,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -6068,6 +7402,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@upstash/ratelimit": "^2.0.8",
+    "@upstash/redis": "^1.37.0",
     "cobe": "^2.0.1",
     "framer-motion": "^12.38.0",
     "lucide-react": "^0.554.0",
@@ -17,7 +19,8 @@
     "react-dom": "^18.3.1",
     "react-google-recaptcha-v3": "^1.11.0",
     "react-phone-number-input": "^3.4.14",
-    "resend": "^6.5.2"
+    "resend": "^6.5.2",
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@types/node": "^20",
@@ -28,6 +31,7 @@
     "eslint-config-next": "^15.5.15",
     "postcss": "^8.4.49",
     "tailwindcss": "^3.4.17",
-    "typescript": "5.9.3"
+    "typescript": "5.9.3",
+    "vitest": "^4.1.5"
   }
 }

--- a/src/app/api/contact/route.test.ts
+++ b/src/app/api/contact/route.test.ts
@@ -1,0 +1,437 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const routeMocks = vi.hoisted(() => ({
+  resendSend: vi.fn(),
+  createLeadId: vi.fn(),
+  persistLeadBackup: vi.fn(),
+  renderContactLeadEmail: vi.fn(),
+  fetch: vi.fn(),
+  recaptchaResponse: {
+    success: true,
+    score: 0.9,
+    action: "contact_form_submit",
+    hostname: "www.northlanterngroup.com",
+  },
+  zeroBounceResponse: { status: "valid" },
+}));
+
+const upstashState = vi.hoisted(() => ({
+  buckets: new Map<string, { count: number; reset: number }>(),
+  redisConfigs: [] as unknown[],
+}));
+
+vi.mock("resend", () => ({
+  Resend: vi.fn().mockImplementation(() => ({
+    emails: {
+      send: routeMocks.resendSend,
+    },
+  })),
+}));
+
+vi.mock("@/lib/leadBackup", () => ({
+  createLeadId: routeMocks.createLeadId,
+  persistLeadBackup: routeMocks.persistLeadBackup,
+}));
+
+vi.mock("@/lib/contactEmail", () => ({
+  renderContactLeadEmail: routeMocks.renderContactLeadEmail,
+}));
+
+vi.mock("@upstash/redis", () => ({
+  Redis: class MockRedis {
+    constructor(config: unknown) {
+      upstashState.redisConfigs.push(config);
+    }
+  },
+}));
+
+vi.mock("@upstash/ratelimit", () => {
+  function windowMs(value: string) {
+    if (value === "3600 s") return 3_600_000;
+    if (value === "60 s") return 60_000;
+    throw new Error(`Unexpected window: ${value}`);
+  }
+
+  class MockRatelimit {
+    private readonly limitCount: number;
+    private readonly window: number;
+    private readonly prefix: string;
+
+    static slidingWindow(tokens: number, window: string) {
+      return { tokens, window };
+    }
+
+    constructor(config: { limiter: { tokens: number; window: string }; prefix: string }) {
+      this.limitCount = config.limiter.tokens;
+      this.window = windowMs(config.limiter.window);
+      this.prefix = config.prefix;
+    }
+
+    async limit(identifier: string) {
+      const key = `${this.prefix}:${identifier}`;
+      const now = Date.now();
+      const existing = upstashState.buckets.get(key);
+      const bucket =
+        existing && existing.reset > now
+          ? existing
+          : { count: 0, reset: now + this.window };
+
+      bucket.count += 1;
+      upstashState.buckets.set(key, bucket);
+
+      return {
+        success: bucket.count <= this.limitCount,
+        limit: this.limitCount,
+        remaining: Math.max(0, this.limitCount - bucket.count),
+        reset: bucket.reset,
+      };
+    }
+  }
+
+  return { Ratelimit: MockRatelimit };
+});
+
+const validSubmission = {
+  firstName: "Ada",
+  lastName: "Lovelace",
+  company: "Audit Synthetic Test",
+  companySize: "11-50",
+  email: "audit@northlanterngroup.com",
+  phone: "+14165550123",
+  service: "general",
+  message: "Read-only audit verification probe; safe to delete.",
+  captchaToken: "captcha-token",
+  website: "",
+  marketingConsent: false,
+  privacyAccepted: true,
+  sourcePage: "https://www.northlanterngroup.com/",
+  referrer: "https://www.northlanterngroup.com/",
+};
+
+function jsonResponse(data: unknown, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function resetEnv() {
+  for (const key of [
+    "VERCEL_ENV",
+    "CONTACT_RATE_LIMIT_ENABLED",
+    "UPSTASH_REDIS_REST_URL",
+    "UPSTASH_REDIS_REST_TOKEN",
+    "RECAPTCHA_SECRET_KEY",
+    "RESEND_API_KEY",
+    "ZEROBOUNCE_API_KEY",
+    "DEBUG_RECAPTCHA",
+  ]) {
+    delete process.env[key];
+  }
+
+  process.env.VERCEL_ENV = "preview";
+  process.env.CONTACT_RATE_LIMIT_ENABLED = "true";
+  process.env.UPSTASH_REDIS_REST_URL = "https://upstash.test";
+  process.env.UPSTASH_REDIS_REST_TOKEN = "upstash-token";
+  process.env.RECAPTCHA_SECRET_KEY = "recaptcha-secret";
+  process.env.RESEND_API_KEY = "resend-key";
+  process.env.ZEROBOUNCE_API_KEY = "zerobounce-key";
+}
+
+function makeRequest(body: unknown = validSubmission, headers: Record<string, string> = {}) {
+  return new Request("https://www.northlanterngroup.com/api/contact", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-forwarded-for": "203.0.113.10, 198.51.100.10",
+      ...headers,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+async function loadPost() {
+  const mod = await import("./route");
+  return mod.POST;
+}
+
+async function post(body: unknown = validSubmission, headers: Record<string, string> = {}) {
+  const POST = await loadPost();
+  return POST(makeRequest(body, headers));
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-04-27T12:00:00.000Z"));
+  resetEnv();
+  upstashState.buckets.clear();
+  upstashState.redisConfigs.length = 0;
+  routeMocks.resendSend.mockReset();
+  routeMocks.resendSend.mockResolvedValue({ data: { id: "email_123" }, error: null });
+  routeMocks.createLeadId.mockReset();
+  routeMocks.createLeadId.mockReturnValue("lead_test");
+  routeMocks.persistLeadBackup.mockReset();
+  routeMocks.persistLeadBackup.mockResolvedValue({
+    enabled: true,
+    ok: true,
+    status: "stored",
+  });
+  routeMocks.renderContactLeadEmail.mockReset();
+  routeMocks.renderContactLeadEmail.mockReturnValue({ text: "text", html: "<p>html</p>" });
+  routeMocks.recaptchaResponse = {
+    success: true,
+    score: 0.9,
+    action: "contact_form_submit",
+    hostname: "www.northlanterngroup.com",
+  };
+  routeMocks.zeroBounceResponse = { status: "valid" };
+  routeMocks.fetch.mockReset();
+  routeMocks.fetch.mockImplementation(async (input: RequestInfo | URL) => {
+    const url = String(input);
+    if (url.includes("google.com/recaptcha")) {
+      return jsonResponse(routeMocks.recaptchaResponse);
+    }
+    if (url.includes("zerobounce.net")) {
+      return jsonResponse(routeMocks.zeroBounceResponse);
+    }
+    throw new Error(`Unexpected fetch: ${url}`);
+  });
+  vi.stubGlobal("fetch", routeMocks.fetch);
+  vi.spyOn(console, "error").mockImplementation(() => undefined);
+  vi.spyOn(console, "warn").mockImplementation(() => undefined);
+  vi.spyOn(console, "log").mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe("POST /api/contact body cap", () => {
+  it("returns 413 when content-length is 16385", async () => {
+    const response = await post(validSubmission, { "content-length": "16385" });
+
+    expect(response.status).toBe(413);
+    await expect(response.json()).resolves.toEqual({ error: "Request body too large." });
+  });
+
+  it("proceeds when content-length is 16384", async () => {
+    const response = await post(validSubmission, { "content-length": "16384" });
+
+    expect(response.status).toBe(200);
+  });
+
+  it("proceeds when content-length is missing", async () => {
+    const response = await post();
+
+    expect(response.status).toBe(200);
+  });
+});
+
+describe("POST /api/contact rate limiting", () => {
+  it("allows 5 requests within 60 seconds and rejects the 6th", async () => {
+    for (let i = 0; i < 5; i += 1) {
+      const response = await post();
+      expect(response.status).toBe(200);
+    }
+
+    const response = await post();
+
+    expect(response.status).toBe(429);
+    expect(response.headers.get("Retry-After")).toBeTruthy();
+    await expect(response.json()).resolves.toEqual({
+      error: "Too many requests. Please wait and try again.",
+    });
+  });
+
+  it("rejects the 21st request within 3600 seconds", async () => {
+    for (let i = 0; i < 20; i += 1) {
+      const response = await post();
+      expect(response.status).toBe(200);
+      if ((i + 1) % 5 === 0) {
+        vi.advanceTimersByTime(61_000);
+      }
+    }
+
+    const response = await post();
+
+    expect(response.status).toBe(429);
+    expect(response.headers.get("Retry-After")).toBeTruthy();
+  });
+
+  it("bypasses rate limiting when CONTACT_RATE_LIMIT_ENABLED is false", async () => {
+    process.env.CONTACT_RATE_LIMIT_ENABLED = "false";
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+
+    const response = await post();
+
+    expect(response.status).toBe(200);
+    expect(upstashState.redisConfigs).toHaveLength(0);
+  });
+
+  it("fails closed when Upstash env is missing in production", async () => {
+    process.env.VERCEL_ENV = "production";
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+
+    const response = await post();
+
+    expect(response.status).toBe(500);
+  });
+
+  it("warns and proceeds when Upstash env is missing outside production", async () => {
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+
+    const response = await post();
+
+    expect(response.status).toBe(200);
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining('"reason":"missing_upstash_env"')
+    );
+  });
+});
+
+describe("POST /api/contact fail-closed behavior", () => {
+  it("returns 500 when production is missing RECAPTCHA_SECRET_KEY", async () => {
+    process.env.VERCEL_ENV = "production";
+    delete process.env.RECAPTCHA_SECRET_KEY;
+
+    const response = await post();
+
+    expect(response.status).toBe(500);
+  });
+
+  it("returns 500 when production is missing RESEND_API_KEY", async () => {
+    process.env.VERCEL_ENV = "production";
+    delete process.env.RESEND_API_KEY;
+
+    const response = await post();
+
+    expect(response.status).toBe(500);
+  });
+
+  it("allows non-production submissions without RECAPTCHA_SECRET_KEY and logs a warning", async () => {
+    delete process.env.RECAPTCHA_SECRET_KEY;
+
+    const response = await post();
+
+    expect(response.status).toBe(200);
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining('"reason":"missing_secret_key_non_production"')
+    );
+  });
+});
+
+describe("POST /api/contact captcha enforcement", () => {
+  it("rejects action mismatch in production", async () => {
+    process.env.VERCEL_ENV = "production";
+    routeMocks.recaptchaResponse = {
+      success: true,
+      score: 0.9,
+      action: "wrong_action",
+      hostname: "www.northlanterngroup.com",
+    };
+
+    const response = await post();
+
+    expect(response.status).toBe(400);
+  });
+
+  it("rejects hostname mismatch in production", async () => {
+    process.env.VERCEL_ENV = "production";
+    routeMocks.recaptchaResponse = {
+      success: true,
+      score: 0.9,
+      action: "contact_form_submit",
+      hostname: "preview.northlanterngroup.com",
+    };
+
+    const response = await post();
+
+    expect(response.status).toBe(400);
+  });
+
+  it("rejects scores below 0.5", async () => {
+    routeMocks.recaptchaResponse = {
+      success: true,
+      score: 0.1,
+      action: "contact_form_submit",
+      hostname: "www.northlanterngroup.com",
+    };
+
+    const response = await post();
+
+    expect(response.status).toBe(400);
+  });
+});
+
+describe("POST /api/contact validation and honeypot", () => {
+  it("returns 400 for a 5001-character message", async () => {
+    const response = await post({
+      ...validSubmission,
+      message: "a".repeat(5001),
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.fieldErrors).toHaveProperty("message");
+  });
+
+  it("returns 400 for an unknown service enum value", async () => {
+    const response = await post({
+      ...validSubmission,
+      service: "made-up-service",
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.fieldErrors).toHaveProperty("service");
+  });
+
+  it("accepts legacy service values and maps them downstream", async () => {
+    const response = await post({
+      ...validSubmission,
+      service: "atlassian-systems",
+    });
+
+    expect(response.status).toBe(200);
+    expect(routeMocks.renderContactLeadEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        serviceDisplay: "Atlassian Platform",
+      })
+    );
+  });
+
+  it("returns silent success when website honeypot is filled", async () => {
+    process.env.CONTACT_RATE_LIMIT_ENABLED = "false";
+
+    const response = await post({
+      ...validSubmission,
+      website: "anything",
+    });
+
+    await expect(response.json()).resolves.toEqual({
+      success: true,
+      leadId: "lead_test",
+      emailStatus: "sent",
+      backupStatus: "stored",
+    });
+    expect(response.status).toBe(200);
+  });
+
+  it("does not call Resend, ZeroBounce, or lead backup when website honeypot is filled", async () => {
+    process.env.CONTACT_RATE_LIMIT_ENABLED = "false";
+
+    await post({
+      ...validSubmission,
+      website: "anything",
+    });
+
+    expect(routeMocks.resendSend).not.toHaveBeenCalled();
+    expect(routeMocks.fetch).not.toHaveBeenCalled();
+    expect(routeMocks.persistLeadBackup).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -1,11 +1,21 @@
 import { Resend } from 'resend';
 import { NextResponse } from 'next/server';
 import { renderContactLeadEmail } from '@/lib/contactEmail';
-import { validateContactSubmission } from '@/lib/contactValidation';
+import {
+  contactSubmissionSchema,
+  getContactFieldErrors,
+  type ContactSubmission,
+} from '@/lib/contactValidation';
 import { createLeadId, persistLeadBackup } from '@/lib/leadBackup';
-// Contact form API with CAPTCHA and email verification
+import { checkRateLimit } from '@/lib/rateLimit';
 
 export const runtime = 'nodejs';
+
+const BODY_SIZE_LIMIT_BYTES = 16 * 1024;
+const EXPECTED_RECAPTCHA_ACTION = 'contact_form_submit';
+const EXPECTED_RECAPTCHA_HOSTNAME = 'www.northlanterngroup.com';
+const RECAPTCHA_SCORE_THRESHOLD = 0.5;
+const DEBUG_RECAPTCHA = process.env.DEBUG_RECAPTCHA === 'true';
 
 // Map service values to display names for email
 const serviceDisplayNames: Record<string, string> = {
@@ -19,10 +29,66 @@ const serviceDisplayNames: Record<string, string> = {
   'bi-operational-reporting': 'BI and Analytics',
 };
 
+type LogLevel = 'error' | 'warn' | 'info';
+type LogService = 'contact_api' | 'recaptcha' | 'zerobounce' | 'resend' | 'lead_backup';
+
+class MissingResendApiKeyError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'MissingResendApiKeyError';
+  }
+}
+
+function isProduction() {
+  return process.env.VERCEL_ENV === 'production';
+}
+
+function toSafeErrorMessage(error: unknown) {
+  if (!(error instanceof Error)) return undefined;
+
+  return error.message
+    .replace(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi, '[email]')
+    .replace(/https?:\/\/\S+/g, '[url]')
+    .slice(0, 200);
+}
+
+function logStructured(
+  level: LogLevel,
+  service: LogService,
+  reason: string,
+  options: { leadId?: string; error?: unknown } = {}
+) {
+  const errorMessage = toSafeErrorMessage(options.error);
+  const payload = {
+    level,
+    service,
+    ...(options.leadId ? { leadId: options.leadId } : {}),
+    reason,
+    ...(errorMessage ? { errorMessage } : {}),
+  };
+  const line = JSON.stringify(payload);
+
+  if (level === 'error') {
+    console.error(line);
+    return;
+  }
+
+  if (level === 'warn') {
+    console.warn(line);
+    return;
+  }
+
+  console.log(line);
+}
+
 function getResendClient() {
   const apiKey = process.env.RESEND_API_KEY;
   if (!apiKey) {
-    throw new Error('RESEND_API_KEY is not configured');
+    throw new MissingResendApiKeyError(
+      isProduction()
+        ? 'RESEND_API_KEY is not configured.'
+        : 'RESEND_API_KEY is not configured. Add it to .env.local to test contact email delivery.'
+    );
   }
   return new Resend(apiKey);
 }
@@ -64,17 +130,39 @@ function cleanUrlForLeadMetadata(value: string) {
 }
 
 function getErrorMessage(error: unknown) {
-  if (error instanceof Error) return error.message.slice(0, 300);
-  return 'Unknown error';
+  return toSafeErrorMessage(error) || 'Unknown error';
+}
+
+function getClientIp(request: Request) {
+  // Vercel forwards client IPs through x-forwarded-for first; x-real-ip is a fallback.
+  const forwardedFor = request.headers.get('x-forwarded-for');
+  const firstForwardedIp = forwardedFor?.split(',')[0]?.trim();
+
+  if (firstForwardedIp) {
+    return firstForwardedIp;
+  }
+
+  return request.headers.get('x-real-ip')?.trim() || 'unknown';
+}
+
+function isBodyTooLarge(request: Request) {
+  const contentLength = request.headers.get('content-length');
+  if (!contentLength || !/^\d+$/.test(contentLength)) {
+    return false;
+  }
+
+  return Number(contentLength) > BODY_SIZE_LIMIT_BYTES;
 }
 
 // Verify email exists using ZeroBounce
-async function verifyEmailExists(email: string): Promise<{ valid: boolean; reason?: string }> {
+async function verifyEmailExists(
+  email: string,
+  leadId: string
+): Promise<{ valid: boolean; reason?: string }> {
   const apiKey = process.env.ZEROBOUNCE_API_KEY;
 
-  // Skip verification in dev mode if no API key
   if (!apiKey) {
-    console.warn('ZEROBOUNCE_API_KEY not configured - skipping email verification');
+    logStructured('warn', 'zerobounce', 'missing_api_key', { leadId });
     return { valid: true };
   }
 
@@ -82,46 +170,58 @@ async function verifyEmailExists(email: string): Promise<{ valid: boolean; reaso
     const response = await fetch(
       `https://api.zerobounce.net/v2/validate?api_key=${apiKey}&email=${encodeURIComponent(email)}`
     );
-    const data = await response.json();
+    const data = (await response.json()) as { status?: string };
 
     // Only block emails that are definitely problematic
     // Be lenient for contact forms - people filling out forms want to be contacted
     const blockedStatuses = ['invalid', 'spamtrap', 'disposable'];
 
-    if (blockedStatuses.includes(data.status)) {
+    if (data.status && blockedStatuses.includes(data.status)) {
       const errorMessages: Record<string, string> = {
-        'invalid': 'This email address does not exist. Please check for typos.',
-        'spamtrap': 'This email address is not valid.',
-        'disposable': 'Please use a permanent email address, not a temporary one.',
+        invalid: 'This email address does not exist. Please check for typos.',
+        spamtrap: 'This email address is not valid.',
+        disposable: 'Please use a permanent email address, not a temporary one.',
       };
       return {
         valid: false,
-        reason: errorMessages[data.status] || 'This email address could not be verified'
+        reason: errorMessages[data.status] || 'This email address could not be verified',
       };
     }
 
     // Allow all other statuses (valid, catch-all, do_not_mail, abuse, unknown)
     return { valid: true };
-  } catch (error) {
-    console.error('ZeroBounce verification error:', error);
+  } catch {
+    logStructured('warn', 'zerobounce', 'fetch_failed', { leadId });
     // Allow through if verification service fails
     return { valid: true };
   }
 }
 
-// Minimum score threshold for reCAPTCHA v3 (0.0 = likely bot, 1.0 = likely human)
-// 0.5 is Google's recommended threshold for most use cases
-const RECAPTCHA_SCORE_THRESHOLD = 0.5;
+type RecaptchaResponse = {
+  success?: boolean;
+  score?: number;
+  action?: string;
+  hostname?: string;
+  'error-codes'?: string[];
+};
 
-// Debug logging flag - set DEBUG_RECAPTCHA=true in env to enable verbose logging
-const DEBUG_RECAPTCHA = process.env.DEBUG_RECAPTCHA === 'true';
+type CaptchaVerificationResult = {
+  success: boolean;
+  error?: string;
+  score?: number;
+  status?: number;
+};
 
-async function verifyCaptcha(token: string): Promise<{ success: boolean; error?: string; score?: number }> {
+async function verifyCaptcha(token: string, leadId: string): Promise<CaptchaVerificationResult> {
   const secretKey = process.env.RECAPTCHA_SECRET_KEY;
 
-  // Skip verification in development if no secret key
   if (!secretKey) {
-    console.warn('RECAPTCHA_SECRET_KEY not configured - allowing submission');
+    if (isProduction()) {
+      logStructured('error', 'recaptcha', 'missing_secret_key', { leadId });
+      return { success: false, error: 'Service temporarily unavailable.', status: 500 };
+    }
+
+    logStructured('warn', 'recaptcha', 'missing_secret_key_non_production', { leadId });
     return { success: true };
   }
 
@@ -129,24 +229,23 @@ async function verifyCaptcha(token: string): Promise<{ success: boolean; error?:
     const response = await fetch('https://www.google.com/recaptcha/api/siteverify', {
       method: 'POST',
       headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-      body: `secret=${secretKey}&response=${token}`,
+      body: new URLSearchParams({
+        secret: secretKey,
+        response: token,
+      }),
     });
-    const data = await response.json();
+    const data = (await response.json()) as RecaptchaResponse;
 
-    // Log for monitoring (gated behind DEBUG_RECAPTCHA flag per code review)
     if (DEBUG_RECAPTCHA) {
-      console.log('reCAPTCHA v3 response:', {
-        success: data.success,
-        score: data.score,
-        action: data.action,
-        hostname: data.hostname,
-      });
+      logStructured('info', 'recaptcha', 'verification_response', { leadId });
     }
 
-    // Check if verification succeeded
     if (!data.success) {
       const errorCodes = data['error-codes'] || [];
-      console.error('reCAPTCHA verification failed:', errorCodes);
+      logStructured('warn', 'recaptcha', 'verification_failed', {
+        leadId,
+        error: new Error(errorCodes.join(',') || 'Unknown reCAPTCHA verification error'),
+      });
 
       if (errorCodes.includes('invalid-input-secret')) {
         return { success: false, error: 'Security verification configuration error.' };
@@ -157,92 +256,126 @@ async function verifyCaptcha(token: string): Promise<{ success: boolean; error?:
       return { success: false, error: 'Security verification failed. Please try again.' };
     }
 
-    // Check score threshold (v3 specific)
+    if (data.action !== EXPECTED_RECAPTCHA_ACTION) {
+      logStructured(isProduction() ? 'error' : 'warn', 'recaptcha', 'action_mismatch', { leadId });
+      if (isProduction()) {
+        return { success: false, error: 'Security verification failed. Please try again.' };
+      }
+    }
+
+    if (data.hostname !== EXPECTED_RECAPTCHA_HOSTNAME) {
+      logStructured(isProduction() ? 'error' : 'warn', 'recaptcha', 'hostname_mismatch', { leadId });
+      if (isProduction()) {
+        return { success: false, error: 'Security verification failed. Please try again.' };
+      }
+    }
+
     const score = data.score || 0;
     if (score < RECAPTCHA_SCORE_THRESHOLD) {
-      console.warn(`reCAPTCHA score too low: ${score} (threshold: ${RECAPTCHA_SCORE_THRESHOLD})`);
+      logStructured('warn', 'recaptcha', 'low_score', { leadId });
       return {
         success: false,
         error: 'Unable to verify your request. Please try again or contact us directly.',
-        score
+        score,
       };
-    }
-
-    // Optionally verify action matches expected value
-    if (data.action && data.action !== 'contact_form_submit') {
-      console.warn(`reCAPTCHA action mismatch: expected 'contact_form_submit', got '${data.action}'`);
-      // Don't fail on action mismatch, just log it
     }
 
     return { success: true, score };
   } catch (error) {
-    console.error('CAPTCHA verification error:', error);
+    logStructured('error', 'recaptcha', 'fetch_failed', { leadId, error });
     return { success: false, error: 'Security verification service unavailable. Please try again.' };
   }
 }
 
+function rateLimitErrorResponse(retryAfter?: number) {
+  return NextResponse.json(
+    { error: 'Too many requests. Please wait and try again.' },
+    {
+      status: 429,
+      headers: retryAfter ? { 'Retry-After': String(retryAfter) } : undefined,
+    }
+  );
+}
+
 export async function POST(request: Request) {
   try {
-    interface ContactFormData {
-      firstName?: string;
-      lastName?: string;
-      company: string;
-      companySize?: string;
-      email: string;
-      phone?: string;
-      service: string;
-      message: string;
-      captchaToken: string;
-      website?: string;
-      marketingConsent?: boolean;
-      privacyAccepted?: boolean;
-      sourcePage?: string;
-      referrer?: string;
+    try {
+      const rateLimit = await checkRateLimit(getClientIp(request));
+      if (!rateLimit.allowed) {
+        return rateLimitErrorResponse(rateLimit.retryAfter);
+      }
+    } catch (error) {
+      logStructured('error', 'contact_api', 'rate_limit_failed_closed', { error });
+      return NextResponse.json(
+        { error: 'Internal server error' },
+        { status: 500 }
+      );
     }
 
-    const { firstName, lastName, company, companySize, email, phone, service, message, captchaToken, website: honeypot, marketingConsent, privacyAccepted, sourcePage, referrer }: ContactFormData = await request.json();
+    if (isBodyTooLarge(request)) {
+      return NextResponse.json(
+        { error: 'Request body too large.' },
+        { status: 413 }
+      );
+    }
 
-    const fieldErrors = validateContactSubmission({
+    let rawSubmission: unknown;
+    try {
+      rawSubmission = await request.json();
+    } catch {
+      return NextResponse.json(
+        { error: 'Invalid request body.' },
+        { status: 400 }
+      );
+    }
+
+    const validationResult = contactSubmissionSchema.safeParse(rawSubmission);
+    if (!validationResult.success) {
+      return NextResponse.json(
+        {
+          error: 'Please correct the highlighted fields.',
+          fieldErrors: getContactFieldErrors(validationResult.error),
+        },
+        { status: 400 }
+      );
+    }
+
+    const {
+      firstName,
+      lastName,
       company,
+      companySize,
       email,
+      phone,
       service,
       message,
-      privacyAccepted,
-    });
+      captchaToken,
+      website: honeypot,
+      marketingConsent,
+      sourcePage,
+      referrer,
+    }: ContactSubmission = validationResult.data;
 
-    if (Object.keys(fieldErrors).length > 0) {
-      return NextResponse.json(
-        { error: 'Please correct the highlighted fields.', fieldErrors },
-        { status: 400 }
-      );
-    }
+    const leadId = createLeadId();
 
-    // Honeypot check - if filled, it's a bot (real users can't see this field)
     if (honeypot) {
-      return NextResponse.json(
-        { error: 'Something went wrong. Please try again.' },
-        { status: 400 }
-      );
+      return NextResponse.json({
+        success: true,
+        leadId,
+        emailStatus: 'sent',
+        backupStatus: 'stored',
+      });
     }
 
-    // Verify CAPTCHA
-    if (!captchaToken) {
-      return NextResponse.json(
-        { error: 'CAPTCHA verification required' },
-        { status: 400 }
-      );
-    }
-
-    const captchaResult = await verifyCaptcha(captchaToken);
+    const captchaResult = await verifyCaptcha(captchaToken, leadId);
     if (!captchaResult.success) {
       return NextResponse.json(
         { error: captchaResult.error || 'CAPTCHA verification failed' },
-        { status: 400 }
+        { status: captchaResult.status || 400 }
       );
     }
 
-    // Verify email actually exists
-    const emailVerification = await verifyEmailExists(email);
+    const emailVerification = await verifyEmailExists(email, leadId);
     if (!emailVerification.valid) {
       return NextResponse.json(
         { error: emailVerification.reason || 'Invalid email address' },
@@ -252,7 +385,6 @@ export async function POST(request: Request) {
 
     const fullName = `${firstName || ''} ${lastName || ''}`.trim() || email;
     const serviceDisplay = serviceDisplayNames[service] || service;
-    const leadId = createLeadId();
     const submittedAt = new Date().toISOString();
     const marketingConsentLabel = marketingConsent ? 'Yes (marketing updates opt-in)' : 'No';
     const safeSourcePage = cleanUrlForLeadMetadata(sourcePage || request.headers.get('referer') || '');
@@ -299,8 +431,12 @@ export async function POST(request: Request) {
       emailStatus = 'sent';
       resendMessageId = data?.id || '';
     } catch (error) {
+      if (error instanceof MissingResendApiKeyError) {
+        throw error;
+      }
+
       emailError = getErrorMessage(error);
-      console.error('Resend error:', emailError);
+      logStructured('error', 'resend', 'send_failed', { leadId, error });
     }
 
     const backupResult = await persistLeadBackup({
@@ -325,7 +461,10 @@ export async function POST(request: Request) {
     });
 
     if (backupResult.enabled && !backupResult.ok) {
-      console.error('Lead backup error:', backupResult.error || 'Unknown lead backup error');
+      logStructured('error', 'lead_backup', 'persist_failed', {
+        leadId,
+        error: new Error(backupResult.error || 'Unknown lead backup error'),
+      });
     }
 
     const hasStoredBackup = backupResult.enabled && backupResult.ok && backupResult.status !== 'disabled';
@@ -344,7 +483,12 @@ export async function POST(request: Request) {
       backupStatus: backupResult.status,
     });
   } catch (error) {
-    console.error('API error:', error);
+    logStructured(
+      'error',
+      'contact_api',
+      error instanceof MissingResendApiKeyError ? 'missing_resend_api_key' : 'unhandled_error',
+      { error }
+    );
     return NextResponse.json(
       { error: 'Internal server error' },
       { status: 500 }

--- a/src/lib/contactValidation.test.ts
+++ b/src/lib/contactValidation.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  CAPTCHA_TOKEN_MAX_LENGTH,
   contactSubmissionSchema,
   getContactFieldErrors,
   validateContactSubmission,
@@ -45,7 +46,7 @@ describe("contactSubmissionSchema", () => {
     ["email", `${"a".repeat(250)}@x.com`],
     ["phone", "1".repeat(31)],
     ["message", "a".repeat(5001)],
-    ["captchaToken", "a".repeat(2049)],
+    ["captchaToken", "a".repeat(CAPTCHA_TOKEN_MAX_LENGTH + 1)],
     ["website", "a".repeat(201)],
     ["sourcePage", "a".repeat(1001)],
     ["referrer", "a".repeat(1001)],
@@ -101,6 +102,15 @@ describe("contactSubmissionSchema", () => {
     });
 
     expect(result.success).toBe(false);
+  });
+
+  it("accepts a real-world reCAPTCHA token length", () => {
+    const result = contactSubmissionSchema.safeParse({
+      ...validSubmission,
+      captchaToken: "a".repeat(2212),
+    });
+
+    expect(result.success).toBe(true);
   });
 
   it("keeps the frontend helper limited to visible contact fields", () => {

--- a/src/lib/contactValidation.test.ts
+++ b/src/lib/contactValidation.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import {
+  contactSubmissionSchema,
+  getContactFieldErrors,
+  validateContactSubmission,
+} from "./contactValidation";
+
+const validSubmission = {
+  firstName: "Ada",
+  lastName: "Lovelace",
+  company: "Analytical Engines Inc.",
+  companySize: "11-50",
+  email: "audit@northlanterngroup.com",
+  phone: "+14165550123",
+  service: "general",
+  message: "We need help improving a production workflow.",
+  captchaToken: "captcha-token",
+  website: "",
+  marketingConsent: false,
+  privacyAccepted: true,
+  sourcePage: "https://www.northlanterngroup.com/",
+  referrer: "https://www.northlanterngroup.com/",
+};
+
+describe("contactSubmissionSchema", () => {
+  it.each(["company", "email", "service", "message", "captchaToken", "privacyAccepted"] as const)(
+    "returns a field-specific error when %s is missing",
+    (field) => {
+      const submission = { ...validSubmission };
+      delete submission[field];
+
+      const result = contactSubmissionSchema.safeParse(submission);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(getContactFieldErrors(result.error)).toHaveProperty(field);
+      }
+    }
+  );
+
+  it.each([
+    ["firstName", "a".repeat(81)],
+    ["lastName", "a".repeat(81)],
+    ["company", "a".repeat(201)],
+    ["email", `${"a".repeat(250)}@x.com`],
+    ["phone", "1".repeat(31)],
+    ["message", "a".repeat(5001)],
+    ["captchaToken", "a".repeat(2049)],
+    ["website", "a".repeat(201)],
+    ["sourcePage", "a".repeat(1001)],
+    ["referrer", "a".repeat(1001)],
+  ] as const)("returns a field-specific error when %s exceeds its max length", (field, value) => {
+    const result = contactSubmissionSchema.safeParse({
+      ...validSubmission,
+      [field]: value,
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(getContactFieldErrors(result.error)).toHaveProperty(field);
+    }
+  });
+
+  it("rejects an unknown service enum value", () => {
+    const result = contactSubmissionSchema.safeParse({
+      ...validSubmission,
+      service: "made-up-service",
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(getContactFieldErrors(result.error)).toHaveProperty("service");
+    }
+  });
+
+  it("accepts legacy service enum values", () => {
+    const result = contactSubmissionSchema.safeParse({
+      ...validSubmission,
+      service: "atlassian-systems",
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects privacyAccepted false", () => {
+    const result = contactSubmissionSchema.safeParse({
+      ...validSubmission,
+      privacyAccepted: false,
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(getContactFieldErrors(result.error)).toHaveProperty("privacyAccepted");
+    }
+  });
+
+  it("rejects unknown extra fields", () => {
+    const result = contactSubmissionSchema.safeParse({
+      ...validSubmission,
+      extra: "not allowed",
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("keeps the frontend helper limited to visible contact fields", () => {
+    expect(
+      validateContactSubmission({
+        company: "Analytical Engines Inc.",
+        email: "audit@northlanterngroup.com",
+        service: "general",
+        message: "We need help improving a production workflow.",
+        privacyAccepted: true,
+      })
+    ).toEqual({});
+  });
+});

--- a/src/lib/contactValidation.ts
+++ b/src/lib/contactValidation.ts
@@ -1,6 +1,70 @@
+import { z } from "zod";
+
 export const CONTACT_MESSAGE_MIN_LENGTH = 30;
 
-export type ContactField = "company" | "email" | "service" | "message" | "privacyAccepted";
+const serviceValues = [
+  "atlassian-platform",
+  "bi-analytics",
+  "automation-integration",
+  "consultant-recovery",
+  "general",
+  "atlassian-systems",
+  "bi-operational-reporting",
+] as const;
+
+const companySizeValues = [
+  "",
+  "1-10",
+  "11-50",
+  "51-200",
+  "201-500",
+  "501-1000",
+  "1000+",
+] as const;
+
+const optionalBoundedString = (max: number) => z.string().trim().max(max).optional();
+
+export const contactSubmissionSchema = z
+  .object({
+    firstName: optionalBoundedString(80),
+    lastName: optionalBoundedString(80),
+    company: z.string().trim().min(1, "Company is required.").max(200),
+    companySize: z.enum(companySizeValues).optional(),
+    email: z
+      .string()
+      .trim()
+      .min(1, "Work email is required.")
+      .max(254)
+      .email("Please enter a valid work email."),
+    phone: optionalBoundedString(30),
+    service: z.enum(serviceValues, {
+      errorMap: () => ({ message: "Please pick what you need help with." }),
+    }),
+    message: z
+      .string()
+      .trim()
+      .min(1, "Please describe what is broken or what you are planning.")
+      .min(
+        CONTACT_MESSAGE_MIN_LENGTH,
+        `Please add at least ${CONTACT_MESSAGE_MIN_LENGTH} characters so we have enough context.`
+      )
+      .max(5000),
+    captchaToken: z.string().trim().min(1).max(2048),
+    website: optionalBoundedString(200),
+    marketingConsent: z.boolean().optional().default(false),
+    privacyAccepted: z.literal(true, {
+      errorMap: () => ({ message: "Please accept the privacy statement to continue." }),
+    }),
+    sourcePage: optionalBoundedString(1000),
+    referrer: optionalBoundedString(1000),
+  })
+  .strict();
+
+export type ContactSubmission = z.infer<typeof contactSubmissionSchema>;
+
+export type ContactField =
+  | keyof ContactSubmission
+  | "privacyAccepted";
 
 export type ContactFieldErrors = Partial<Record<ContactField, string>>;
 
@@ -12,31 +76,43 @@ export interface ContactValidationInput {
   privacyAccepted?: boolean;
 }
 
-export function validateContactSubmission(input: ContactValidationInput): ContactFieldErrors {
+const clientValidationSchema = contactSubmissionSchema.pick({
+  company: true,
+  email: true,
+  service: true,
+  message: true,
+  privacyAccepted: true,
+});
+
+const defaultFieldMessages: Partial<Record<ContactField, string>> = {
+  company: "Company is required.",
+  email: "Work email is required.",
+  service: "Please pick what you need help with.",
+  message: "Please describe what is broken or what you are planning.",
+  privacyAccepted: "Please accept the privacy statement to continue.",
+};
+
+export function getContactFieldErrors(error: z.ZodError): ContactFieldErrors {
   const errors: ContactFieldErrors = {};
-  const message = input.message?.trim() || "";
 
-  if (!input.company?.trim()) {
-    errors.company = "Company is required.";
-  }
+  for (const issue of error.issues) {
+    const field = issue.path[0];
+    if (typeof field !== "string") continue;
+    if (errors[field as ContactField]) continue;
 
-  if (!input.email?.trim()) {
-    errors.email = "Work email is required.";
-  }
-
-  if (!input.service?.trim()) {
-    errors.service = "Please pick what you need help with.";
-  }
-
-  if (!message) {
-    errors.message = "Please describe what is broken or what you are planning.";
-  } else if (message.length < CONTACT_MESSAGE_MIN_LENGTH) {
-    errors.message = `Please add at least ${CONTACT_MESSAGE_MIN_LENGTH} characters so we have enough context.`;
-  }
-
-  if (!input.privacyAccepted) {
-    errors.privacyAccepted = "Please accept the privacy statement to continue.";
+    errors[field as ContactField] =
+      issue.message || defaultFieldMessages[field as ContactField] || "Invalid value.";
   }
 
   return errors;
+}
+
+export function validateContactSubmission(input: ContactValidationInput): ContactFieldErrors {
+  const result = clientValidationSchema.safeParse(input);
+
+  if (result.success) {
+    return {};
+  }
+
+  return getContactFieldErrors(result.error);
 }

--- a/src/lib/contactValidation.ts
+++ b/src/lib/contactValidation.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 export const CONTACT_MESSAGE_MIN_LENGTH = 30;
+export const CAPTCHA_TOKEN_MAX_LENGTH = 4096;
 
 const serviceValues = [
   "atlassian-platform",
@@ -49,7 +50,7 @@ export const contactSubmissionSchema = z
         `Please add at least ${CONTACT_MESSAGE_MIN_LENGTH} characters so we have enough context.`
       )
       .max(5000),
-    captchaToken: z.string().trim().min(1).max(2048),
+    captchaToken: z.string().trim().min(1).max(CAPTCHA_TOKEN_MAX_LENGTH),
     website: optionalBoundedString(200),
     marketingConsent: z.boolean().optional().default(false),
     privacyAccepted: z.literal(true, {

--- a/src/lib/rateLimit.ts
+++ b/src/lib/rateLimit.ts
@@ -1,0 +1,108 @@
+import { Ratelimit } from "@upstash/ratelimit";
+import { Redis } from "@upstash/redis";
+
+type CheckRateLimitResult = {
+  allowed: boolean;
+  retryAfter?: number;
+};
+
+type Limiters = {
+  minute: Ratelimit;
+  hour: Ratelimit;
+};
+
+let cachedLimiters: Limiters | null = null;
+
+class RateLimitConfigurationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "RateLimitConfigurationError";
+  }
+}
+
+function isProduction() {
+  return process.env.VERCEL_ENV === "production";
+}
+
+function logStructuredWarning(reason: string, error?: unknown) {
+  const message = error instanceof Error
+    ? error.message
+      .replace(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi, "[email]")
+      .replace(/https?:\/\/\S+/g, "[url]")
+      .slice(0, 200)
+    : undefined;
+  console.warn(
+    JSON.stringify({
+      level: "warn",
+      service: "rate_limit",
+      reason,
+      ...(message ? { errorMessage: message } : {}),
+    })
+  );
+}
+
+function getLimiters(): Limiters | null {
+  const url = process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+
+  if (!url || !token) {
+    if (isProduction()) {
+      throw new RateLimitConfigurationError("Upstash Redis is not configured.");
+    }
+
+    logStructuredWarning("missing_upstash_env");
+    return null;
+  }
+
+  if (!cachedLimiters) {
+    const redis = new Redis({ url, token });
+    cachedLimiters = {
+      minute: new Ratelimit({
+        redis,
+        limiter: Ratelimit.slidingWindow(5, "60 s"),
+        prefix: "contact:ip:60s",
+      }),
+      hour: new Ratelimit({
+        redis,
+        limiter: Ratelimit.slidingWindow(20, "3600 s"),
+        prefix: "contact:ip:3600s",
+      }),
+    };
+  }
+
+  return cachedLimiters;
+}
+
+export async function checkRateLimit(ip: string): Promise<CheckRateLimitResult> {
+  if (process.env.CONTACT_RATE_LIMIT_ENABLED === "false") {
+    return { allowed: true };
+  }
+
+  const limiters = getLimiters();
+  if (!limiters) {
+    return { allowed: true };
+  }
+
+  try {
+    const [minute, hour] = await Promise.all([
+      limiters.minute.limit(ip),
+      limiters.hour.limit(ip),
+    ]);
+
+    if (minute.success && hour.success) {
+      return { allowed: true };
+    }
+
+    const reset = Math.max(minute.reset, hour.reset);
+    const retryAfter = Math.max(1, Math.ceil((reset - Date.now()) / 1000));
+
+    return { allowed: false, retryAfter };
+  } catch (error) {
+    if (isProduction()) {
+      throw error;
+    }
+
+    logStructuredWarning("upstash_check_failed", error);
+    return { allowed: true };
+  }
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,15 @@
+import path from "node:path";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "src"),
+    },
+  },
+  test: {
+    environment: "node",
+    clearMocks: true,
+    restoreMocks: true,
+  },
+});


### PR DESCRIPTION
## Summary
- Add strict zod validation, 16 KB body cap, and honeypot silent success for /api/contact
- Add Upstash Redis sliding-window rate limits with production fail-closed behavior
- Enforce production reCAPTCHA action/hostname and strip PII from structured route logs

## Local verification
- npm run lint: pass
- npx tsc --noEmit: pass
- npx vitest run: 40 passed
- npm run build: pass

## Preview verification
Pending Vercel CLI authentication and Upstash database/env setup.